### PR TITLE
fix One Login Home appearing in history|

### DIFF
--- a/clients/oneLoginHome.ts
+++ b/clients/oneLoginHome.ts
@@ -8,7 +8,7 @@ const oneLoginHome: Client = {
   },
   isAvailableInWelsh: true,
   isAllowed: true,
-  clientType: "service",
+  clientType: "home",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
   showInClientSearch: { production: false, nonProduction: false },

--- a/interfaces/client.interface.ts
+++ b/interfaces/client.interface.ts
@@ -22,7 +22,7 @@ interface BaseClient {
     en: Translations;
   };
   isAllowed: boolean;
-  clientType: "service" | "account";
+  clientType: "service" | "account" | "home";
   isHmrc: boolean;
   isReportSuspiciousActivityEnabled: boolean;
   showInClientSearch: EnvironmentValue<boolean>;

--- a/interfaces/registry.interface.ts
+++ b/interfaces/registry.interface.ts
@@ -1,7 +1,7 @@
 export interface RegistryEntry {
   clientId: string;
   isAllowed: boolean;
-  clientType: "service" | "account";
+  clientType: "service" | "account" | "home";
   isHmrc: boolean;
   isReportSuspiciousActivityEnabled: boolean;
   showInClientSearch: boolean;


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Fix an issue where One Login Home was appearing in production. By changing the account type to `null` for One Login Home, it will not appear in the account list on frontend, which will exclude it.

### Why did it change

This was missed in the requirements gathering stage

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

- [ ] Application configuration is up-to-date
- [ ] Documented in the README

### Testing

### Sign-offs

- [ ] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
