### PR TITLE
Enable Activity History in Apprenticeships Service adn Find an Appren…

### DIFF
--- a/clients/apprenticeshipsService.ts
+++ b/clients/apprenticeshipsService.ts
@@ -11,7 +11,7 @@ const apprenticeshipsService: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/faa.ts
+++ b/clients/faa.ts
@@ -11,7 +11,7 @@ const faa: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2550] Add additional RPs to the activity history allow list

### What changed
<!-- Describe the changes in detail - the "what"-->
Configured Find an Apprenticeship and Apprenticeship services to use activity history

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
To increase the volume of users using the feature to ~50% of OLH users.

### Testing
Deployed to Dev

## How to review
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
Validated the activity history section show's up when the user has either of the rps in their user_services

[OLH-2550]: https://govukverify.atlassian.net/browse/OLH-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ