### PR TITLE
[OLH-2529] Pass language selection to DBS Submit a Barring Referral

### DIFF
--- a/clients/dbsSubmitABarringReferral.ts
+++ b/clients/dbsSubmitABarringReferral.ts
@@ -20,7 +20,7 @@ const dbsSubmitABarringReferral: Client = {
         "Submit a barring referral if you are concerned that an individual may have harmed, or put at risk, a child or vulnerable adult.",
       linkText: "Go to your Submit a barring referral account",
       linkUrl:
-        "https://www.submit-a-barring-referral.service.gov.uk/save-and-return/dashboard",
+        "https://www.submit-a-barring-referral.service.gov.uk/save-and-return/dashboard?lang=en",
     },
     cy: {
       header: "Cyflwyno atgyfeiriad gwahardd",
@@ -28,7 +28,7 @@ const dbsSubmitABarringReferral: Client = {
         "Cyflwyno atgyfeiriad gwahardd os ydych yn poeni y gallai plentyn, neu oedolyn bregus, fod mewn perygl.",
       linkText: "Ewch i'ch Cyfrif Cyflwyno atgyfeiriad gwahardd",
       linkUrl:
-        "https://www.submit-a-barring-referral.service.gov.uk/save-and-return/dashboard",
+        "https://www.submit-a-barring-referral.service.gov.uk/save-and-return/dashboard?lang=cy",
     },
   },
 };


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2529] Pass language selection to DBS Submit a Barring Referral

### What changed
<!-- Describe the changes in detail - the "what"-->
Minor change to pass language selection in URL when I user is redirected to a DBS Submit a Barring Referral.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Review from UCD highlighted that the link does not persist the current selected language.

[OLH-2529]: https://govukverify.atlassian.net/browse/OLH-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ