### PR TITLE
OLH-2566: Enable the activity history for all users

### DIFF
--- a/clients/oneLoginHome.ts
+++ b/clients/oneLoginHome.ts
@@ -11,7 +11,7 @@ const oneLoginHome: Client = {
   clientType: "home",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add Home as an allowed activity log service. This effectively rolls the feature out to everyone as any user who's logged into Home to view their activity history must by definition have Home in their service history.
### Why did it change

The Fraud team have given us the go-ahead to release this feature to all users following our slow rollout trial period. This is the simplest way to do that release that also allows us to roll it back later if we need to. 

### Related links

[Slack conversation with approval to release.](https://gds.slack.com/archives/C02F70D2LQN/p1744630647115329)

## Checklists

- [x] Application configuration is up-to-date