### PR TITLE
[OLH-2404] Create a function to return all the clientIds

### DIFF
--- a/src/get-clientIds.ts
+++ b/src/get-clientIds.ts
@@ -1,0 +1,15 @@
+import * as clients from "../clients";
+import { getValueForEnvironment } from "./utils";
+
+const getClientIds = (environment: string): string[] => {
+  const clientIds: string[] = [];
+  for (const client in clients) {
+    if (client !== "__esModule") {
+      const clientData = clients[client as keyof typeof clients];
+      clientIds.push(getValueForEnvironment(environment, clientData.clientId));
+    }
+  }
+  return clientIds;
+};
+
+export default getClientIds;

--- a/src/get-translations.ts
+++ b/src/get-translations.ts
@@ -27,9 +27,8 @@ const getTranslations = (
 ): TranslationsObject => {
   const translations: TranslationsObject = {};
 
-  Object.keys(clients)
-    .filter((key) => key !== "__esModule") //this is required for the tests to work
-    .forEach((client) => {
+  Object.keys(clients).forEach((client) => {
+    if (client !== "__esModule") {
       const clientData = clients[client as keyof typeof clients];
       const clientTranslations =
         clientData.isAvailableInWelsh && language === "cy"
@@ -41,7 +40,8 @@ const getTranslations = (
         clientTranslations,
         environment
       );
-    });
+    }
+  });
 
   return translations;
 };

--- a/tests/get-clientIds.test.ts
+++ b/tests/get-clientIds.test.ts
@@ -1,0 +1,78 @@
+import { expect, test, describe, jest } from "@jest/globals";
+import getClientIds from "../src/get-clientIds";
+
+jest.mock("../clients", () => ({
+  __esModule: true,
+  cyClient: {
+    isAvailableInWelsh: true,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+      },
+      cy: {
+        header: "header cy",
+        linkText: "link text cy",
+        linkUrl: {
+          production: "link url cy production",
+          nonProduction: "link url cy non production",
+        },
+      },
+    },
+    clientId: "welshClient",
+    clientType: "account",
+    isAllowed: true,
+    isHmrc: false,
+    isReportSuspiciousActivityEnabled: false,
+    showInClientSearch: true,
+  },
+  enClient: {
+    isAvailableInWelsh: false,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+        description: "description en",
+      },
+    },
+    clientId: "englishClient",
+    clientType: "account",
+    isAllowed: true,
+    isHmrc: false,
+    isReportSuspiciousActivityEnabled: false,
+    showInClientSearch: true,
+  },
+  hmrcClient: {
+    isAvailableInWelsh: false,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+        description: "description en",
+        hintText: "hint text en",
+        paragraph1: "paragraph 1 en",
+        paragraph2: "paragraph 2 en",
+      },
+    },
+    clientId: "englishClientHmrc",
+    clientType: "account",
+    isAllowed: true,
+    isHmrc: false,
+    isReportSuspiciousActivityEnabled: false,
+    showInClientSearch: true,
+  },
+}));
+
+describe("getClientIds", () => {
+  test("should return translations in english", async () => {
+    const clientIds = getClientIds("test");
+    expect(clientIds).toStrictEqual([
+      "welshClient",
+      "englishClient",
+      "englishClientHmrc",
+    ]);
+  });
+});


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
[OLH-2404] Create a function to return all the clientIds

### What changed
<!-- Describe the changes in detail - the "what"-->
Implemented a function that will only return all the client Ids reducing the slight overhead compared to transforming the fullc client ID object.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Required for the backend lambda's so that we can log if an unexpected client ID is causing writes to our databases. This will then allow us to action it faster.