### PR TITLE
OLH-2654 - Onboard RP: HO: Online APIS

### DIFF
--- a/clients/hoOnlineApis.ts
+++ b/clients/hoOnlineApis.ts
@@ -1,0 +1,34 @@
+import { Client } from "../interfaces/client.interface";
+
+const hoOnlineApis: Client = {
+  clientId: {
+    production: "B-T4i1nN4hvNEKuxNAzrjzc917o",
+    integration: "B-T4i1nN4hvNEKuxNAzrjzc917o",
+    nonProduction: "hoOnlineApis",
+  },
+  isAvailableInWelsh: false,
+  clientType: "account",
+  isHmrc: false,
+  isReportSuspiciousActivityEnabled: false,
+  isActivityLogEnabled: false,
+  showInClientSearch: { production: true, nonProduction: true },
+  translations: {
+    en: {
+      header: "Online APIS",
+      description:
+        "Submit an online APIS (advance passenger information submission) report if you are a carrier of a scheduled aviation aircraft intending to travel to or from the UK.",
+      linkText: "Go to your Online APIS account",
+      linkUrl: {
+        nonProduction:
+          "https://www.submit-an-online-apis-report.service.gov.uk/dashboard",
+        integration:
+          "https://www.submit-an-online-apis-report.service.gov.uk/dashboard",
+        production:
+          "https://www.submit-an-online-apis-report.service.gov.uk/dashboard",
+      },
+    },
+  },
+  isOffboarded: false,
+};
+
+export default hoOnlineApis;

--- a/clients/index.ts
+++ b/clients/index.ts
@@ -62,6 +62,7 @@ import welshGovChildcareOfferForWalesParents from "./welshGovChildcareOfferForWa
 import welshGovChildcareOfferForWalesProviders from "./welshGovChildcareOfferForWalesProviders";
 import hoDORS from "./hoDORS";
 import securityTokenService from "./securityTokenService";
+import hoOnlineApis from "./hoOnlineApis";
 
 export {
   govuk,
@@ -128,4 +129,5 @@ export {
   welshGovChildcareOfferForWalesProviders,
   hoDORS,
   securityTokenService,
+  hoOnlineApis,
 };


### PR DESCRIPTION
## Proposed changes

OLH-2654 - Onboard RP: HO: Online APIS

### What changed

Added new RP - Home Office Online APIS

### Why did it change

So that we can onboard Home Office Online APIS replying party
### Related links

## Checklists

### Testing

Deploy to dev and test

### Sign-offs

## How to review
