### PR TITLE
OLH-2648: add gitlint commit-msg hook to standardise commit messages

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,20 @@
+[general]
+verbosity=3
+ignore=body-is-missing
+ignore-fixup-commits=false
+ignore-fixup-amend-commits=false
+ignore-squash-commits=false
+regex-style-search=true
+staged=true
+
+[title-max-length]
+line-length=72
+
+[title-min-length]
+min-length=10
+
+[title-match-regex]
+regex=^(BAU|OLH-[0-9]{1,4})[: ]+\w
+
+[author-valid-email]
+regex=[\w\.\+_-]+@(digital.cabinet-office.gov.uk|dsit.gov.uk|users.noreply.github.com)

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+cat $1 | gitlint

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # di-account-management-client-registry
+
+## Prerequisites
+
+We recommend using [`nvm`](https://github.com/nvm-sh/nvm) to install and manage Node.js versions. Run:
+
+```
+nvm install
+```
+
+from the root of the repository to install the correct version of Node.
+
+
+## Gitlint
+
+This repository uses [Gitlint](https://jorisroovers.com/gitlint/latest/) to lint git commit messages.
+
+Install Gitlint by running:
+
+```bash
+pip install gitlint # or `brew install gitlint` if using the Homebrew package manager
+```


### PR DESCRIPTION
### What changed

- Added Gitlint config
- Added NVM and Gitlint instructions to README
- Added `commit-msg` Git hook using Husky which pipes the commit message to Gitlint

### Why did it change

To ensure commit messages are consistently formatted, including the Jira ticket number

### Related links

https://govukverify.atlassian.net/browse/OLH-2648

## Checklists

- [x] Application configuration is up-to-date
- [x] Documented in the README