### PR TITLE
OLH-2507 resolve env specific values when filtering clients

### DIFF
--- a/src/filter-clients.ts
+++ b/src/filter-clients.ts
@@ -1,7 +1,7 @@
 import * as clients from "../clients";
 import { Client } from "../interfaces/client.interface";
 import { RegistryEntry } from "../interfaces/registry.interface";
-import { transformClientObject } from "./utils";
+import { getValueForEnvironment, transformClientObject } from "./utils";
 
 const filterClients = (
   environment: string,
@@ -12,7 +12,10 @@ const filterClients = (
       return (
         client.clientId !== undefined &&
         Object.entries(filters).every(([key, value]) => {
-          return client[key as keyof Client] === value;
+          return (
+            getValueForEnvironment(environment, client[key as keyof Client]) ===
+            value
+          );
         })
       );
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ const getEnvironmentType = (
   return "nonProduction";
 };
 
-const getValueForEnvironment = <T>(
+export const getValueForEnvironment = <T>(
   environment: string,
   value: EnvironmentValue<T>
 ): T => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ const getEnvironmentType = (
   return "nonProduction";
 };
 
-export const getValueForEnvironment = <T>(
+const getValueForEnvironment = <T>(
   environment: string,
   value: EnvironmentValue<T>
 ): T => {

--- a/tests/filter-clients.test.ts
+++ b/tests/filter-clients.test.ts
@@ -27,7 +27,7 @@ jest.mock("../clients", () => ({
     clientType: "account",
     isHmrc: false,
     isReportSuspiciousActivityEnabled: false,
-    showInClientSearch: true,
+    showInClientSearch: { production: true, nonProduction: true },
     isOffboarded: false,
   },
   enClient: {
@@ -44,7 +44,7 @@ jest.mock("../clients", () => ({
     clientType: "account",
     isHmrc: false,
     isReportSuspiciousActivityEnabled: false,
-    showInClientSearch: true,
+    showInClientSearch: { production: true, nonProduction: false },
     isOffboarded: false,
   },
   hmrcClient: {
@@ -64,7 +64,7 @@ jest.mock("../clients", () => ({
     clientType: "account",
     isHmrc: true,
     isReportSuspiciousActivityEnabled: false,
-    showInClientSearch: true,
+    showInClientSearch: { production: true, nonProduction: false },
     isOffboarded: false,
   },
   internalClient: {
@@ -73,7 +73,7 @@ jest.mock("../clients", () => ({
     clientType: "internal",
     isHmrc: false,
     isReportSuspiciousActivityEnabled: false,
-    showInClientSearch: false,
+    showInClientSearch: { production: false, nonProduction: true },
   },
   offboardedClient: {
     isAvailableInWelsh: false,
@@ -128,6 +128,29 @@ describe("filterClient", () => {
         isOffboarded: false,
       },
     ]);
+  });
+
+  test("should work with boolean filters", () => {
+    const result = filterClients("nonProduction", { isHmrc: true });
+    expect(result).toHaveLength(1);
+  });
+
+  test("should work with filters that have environment-specific values", () => {
+    const result = filterClients("production", { showInClientSearch: true });
+    expect(result).toHaveLength(3);
+
+    const result2 = filterClients("nonProduction", {
+      showInClientSearch: true,
+    });
+    expect(result2).toHaveLength(2);
+
+    const result3 = filterClients("production", { showInClientSearch: false });
+    expect(result3).toHaveLength(2);
+
+    const result4 = filterClients("nonProduction", {
+      showInClientSearch: false,
+    });
+    expect(result4).toHaveLength(3);
   });
 
   test('should return clients matching multiple filters (clientType: "account", isOffboarded: false)', () => {

--- a/tests/filter-clients.test.ts
+++ b/tests/filter-clients.test.ts
@@ -108,7 +108,7 @@ describe("filterClient", () => {
         isAvailableInWelsh: false,
         isHmrc: true,
         isReportSuspiciousActivityEnabled: false,
-        showInClientSearch: true,
+        showInClientSearch: false,
         isOffboarded: false,
       },
     ]);


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

This PR updates the filterClients function so that we resolve environment specific values before filtering. 

### Why did it change

Fixes a bug, where you could not filter on environment specific values

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

- [ ] Application configuration is up-to-date
- [ ] Documented in the README

### Testing

### Sign-offs

- [ ] New Node.JS/NPM dependencies have been signed-off by a Lead dev or Lead SRE

## How to review

<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
