### PR TITLE
OLH-2803: Add RPs to activity History

### DIFF
--- a/clients/CMAD.ts
+++ b/clients/CMAD.ts
@@ -10,7 +10,7 @@ const CMAD: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/PDPConnect.ts
+++ b/clients/PDPConnect.ts
@@ -10,7 +10,7 @@ const PDPConnect: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/UKSBS.ts
+++ b/clients/UKSBS.ts
@@ -10,7 +10,7 @@ const ukSBS: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/aas.ts
+++ b/clients/aas.ts
@@ -10,7 +10,7 @@ const aas: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/airPollutionAssesment.ts
+++ b/clients/airPollutionAssesment.ts
@@ -10,7 +10,7 @@ const airPollutionAssesment: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/apar.ts
+++ b/clients/apar.ts
@@ -10,7 +10,7 @@ const apar: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/ate.ts
+++ b/clients/ate.ts
@@ -10,7 +10,7 @@ const ate: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/checkFamilyEligibility.ts
+++ b/clients/checkFamilyEligibility.ts
@@ -10,7 +10,7 @@ const checkFamilyEligibility: Client = {
   clientType: "service",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/coClientServiceJobs.ts
+++ b/clients/coClientServiceJobs.ts
@@ -10,7 +10,7 @@ const coClientServiceJobs: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/companyHouseAccounts.ts
+++ b/clients/companyHouseAccounts.ts
@@ -10,7 +10,7 @@ const companyHouseAccounts: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/connectFamilies.ts
+++ b/clients/connectFamilies.ts
@@ -10,7 +10,7 @@ const connectFamilies: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/criminalInjuriesCompensation.ts
+++ b/clients/criminalInjuriesCompensation.ts
@@ -10,7 +10,7 @@ const criminalInjuriesCompensation: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/dbTrade.ts
+++ b/clients/dbTrade.ts
@@ -10,7 +10,7 @@ const dbTrade: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/dbs.ts
+++ b/clients/dbs.ts
@@ -10,7 +10,7 @@ const dbs: Client = {
   clientType: "service",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/dbsSubmitABarringReferral.ts
+++ b/clients/dbsSubmitABarringReferral.ts
@@ -10,7 +10,7 @@ const dbsSubmitABarringReferral: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/dbtApplyForAnExportCertificate.ts
+++ b/clients/dbtApplyForAnExportCertificate.ts
@@ -10,7 +10,7 @@ const dbtApplyForAnExportCertificate: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/dbtApplyForAnImportLicense.ts
+++ b/clients/dbtApplyForAnImportLicense.ts
@@ -10,7 +10,7 @@ const dbtApplyForAnImportLicense: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/defraDangerousDogsIndex.ts
+++ b/clients/defraDangerousDogsIndex.ts
@@ -10,7 +10,7 @@ const defraDangerousDogsIndex: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/dfeApplyForTeacherTraining.ts
+++ b/clients/dfeApplyForTeacherTraining.ts
@@ -10,7 +10,7 @@ const dfeApplyForTeacherTraining: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/dfeClaimAdditionalPayments.ts
+++ b/clients/dfeClaimAdditionalPayments.ts
@@ -10,7 +10,7 @@ const dfeClaimAdditionalPayments: Client = {
   clientType: "service",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/dfeFindAndUseAnApi.ts
+++ b/clients/dfeFindAndUseAnApi.ts
@@ -10,7 +10,7 @@ const dfeFindAndUseAnApi: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/dfeQualifiedTeacherStatus.ts
+++ b/clients/dfeQualifiedTeacherStatus.ts
@@ -10,7 +10,7 @@ const dfeQualifiedTeacherStatus: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/drivingMedicalCondition.ts
+++ b/clients/drivingMedicalCondition.ts
@@ -10,7 +10,7 @@ const drivingMedicalCondition: Client = {
   clientType: "service",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/dvlaDriverAndVehiclesAccount.ts
+++ b/clients/dvlaDriverAndVehiclesAccount.ts
@@ -10,7 +10,7 @@ const dvlaDriverAndVehiclesAccount: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/findATender.ts
+++ b/clients/findATender.ts
@@ -10,7 +10,7 @@ const findATender: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/findAndApplyForAGrant.ts
+++ b/clients/findAndApplyForAGrant.ts
@@ -10,7 +10,7 @@ const findAndApplyForAGrant: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/firs.ts
+++ b/clients/firs.ts
@@ -10,7 +10,7 @@ const firs: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/heatNetworkZoning.ts
+++ b/clients/heatNetworkZoning.ts
@@ -10,7 +10,7 @@ const heatNetworkZoning: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/hmpoCancelPassport.ts
+++ b/clients/hmpoCancelPassport.ts
@@ -10,7 +10,7 @@ const hmpoCancelPassport: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/hmrc.ts
+++ b/clients/hmrc.ts
@@ -10,7 +10,7 @@ const hmrc: Client = {
   clientType: "service",
   isHmrc: true,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/hmrcGovernmentGateway.ts
+++ b/clients/hmrcGovernmentGateway.ts
@@ -10,7 +10,7 @@ const hmrcGovernmentGateway: Client = {
   clientType: "internal",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: { en: {} },
   isOffboarded: false,

--- a/clients/hoDORS.ts
+++ b/clients/hoDORS.ts
@@ -10,7 +10,7 @@ const hoDORS: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/hoOnlineApis.ts
+++ b/clients/hoOnlineApis.ts
@@ -10,7 +10,7 @@ const hoOnlineApis: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/homeOfficeSEAS.ts
+++ b/clients/homeOfficeSEAS.ts
@@ -10,7 +10,7 @@ const homeOfficeSEAS: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/iaa.ts
+++ b/clients/iaa.ts
@@ -10,7 +10,7 @@ const iaa: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/icsDesnz.ts
+++ b/clients/icsDesnz.ts
@@ -10,7 +10,7 @@ const icsDesnz: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/intellectualPropertyOffice.ts
+++ b/clients/intellectualPropertyOffice.ts
@@ -10,7 +10,7 @@ const intellectualPropertyOffice: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/lite.ts
+++ b/clients/lite.ts
@@ -10,7 +10,7 @@ const lite: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/manageFamilySupport.ts
+++ b/clients/manageFamilySupport.ts
@@ -10,7 +10,7 @@ const manageFamilySupport: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/modernSlavery.ts
+++ b/clients/modernSlavery.ts
@@ -10,7 +10,7 @@ const modernSlavery: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/mojPlanYourFuture.ts
+++ b/clients/mojPlanYourFuture.ts
@@ -10,7 +10,7 @@ const mojPlanYourFuture: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/ofgemLafReg.ts
+++ b/clients/ofgemLafReg.ts
@@ -10,7 +10,7 @@ const ofgemLafReg: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/ofqual.ts
+++ b/clients/ofqual.ts
@@ -10,7 +10,7 @@ const ofqual: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/prisonVisits.ts
+++ b/clients/prisonVisits.ts
@@ -10,7 +10,7 @@ const prisonVisits: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/ruralPaymentWales.ts
+++ b/clients/ruralPaymentWales.ts
@@ -10,7 +10,7 @@ const ruralPaymentWales: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/socialWorkEngland.ts
+++ b/clients/socialWorkEngland.ts
@@ -10,7 +10,7 @@ const socialWorkEngland: Client = {
   clientType: "service",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/ukmcab.ts
+++ b/clients/ukmcab.ts
@@ -10,7 +10,7 @@ const ukmcab: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/useLastingPowerOfAttorney.ts
+++ b/clients/useLastingPowerOfAttorney.ts
@@ -10,7 +10,7 @@ const useLastingPowerOfAttorney: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/veteransCard.ts
+++ b/clients/veteransCard.ts
@@ -10,7 +10,7 @@ const veteransCard: Client = {
   clientType: "service",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/welshFisheriesPermit.ts
+++ b/clients/welshFisheriesPermit.ts
@@ -10,7 +10,7 @@ const welshFisheriesPermit: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: true, nonProduction: true },
   translations: {
     en: {

--- a/clients/welshGovChildcareOfferForWalesParents.ts
+++ b/clients/welshGovChildcareOfferForWalesParents.ts
@@ -10,7 +10,7 @@ const welshGovChildcareOfferForWalesParents: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/clients/welshGovChildcareOfferForWalesProviders.ts
+++ b/clients/welshGovChildcareOfferForWalesProviders.ts
@@ -10,7 +10,7 @@ const welshGovChildcareOfferForWalesProviders: Client = {
   clientType: "account",
   isHmrc: false,
   isReportSuspiciousActivityEnabled: false,
-  isActivityLogEnabled: false,
+  isActivityLogEnabled: true,
   showInClientSearch: { production: false, nonProduction: false },
   translations: {
     en: {

--- a/tests/filter-clients.test.ts
+++ b/tests/filter-clients.test.ts
@@ -104,7 +104,7 @@ describe("filterClient", () => {
       {
         clientId: "hmrcClient",
         clientType: "account",
-        isActivityLogEnabled: false,
+        isActivityLogEnabled: true,
         isAvailableInWelsh: false,
         isHmrc: true,
         isReportSuspiciousActivityEnabled: false,
@@ -120,7 +120,7 @@ describe("filterClient", () => {
       {
         clientId: "welshClientNonProd",
         clientType: "account",
-        isActivityLogEnabled: false,
+        isActivityLogEnabled: true,
         isAvailableInWelsh: true,
         isHmrc: false,
         isReportSuspiciousActivityEnabled: false,
@@ -177,7 +177,7 @@ describe("filterClient", () => {
       {
         clientId: "welshClientProd",
         clientType: "account",
-        isActivityLogEnabled: false,
+        isActivityLogEnabled: true,
         isAvailableInWelsh: true,
         isHmrc: false,
         isReportSuspiciousActivityEnabled: false,
@@ -193,7 +193,7 @@ describe("filterClient", () => {
       {
         clientId: "welshClientNonProd",
         clientType: "account",
-        isActivityLogEnabled: false,
+        isActivityLogEnabled: true,
         isAvailableInWelsh: true,
         isHmrc: false,
         isReportSuspiciousActivityEnabled: false,

--- a/tests/get-client.test.ts
+++ b/tests/get-client.test.ts
@@ -72,7 +72,7 @@ describe("getClient", () => {
     expect(client).toEqual({
       clientId: "welshClientNonProd",
       clientType: "account",
-      isActivityLogEnabled: false,
+      isActivityLogEnabled: true,
       isAvailableInWelsh: true,
       isHmrc: false,
       isReportSuspiciousActivityEnabled: false,
@@ -85,7 +85,7 @@ describe("getClient", () => {
     expect(client).toEqual({
       clientId: "welshClientProd",
       clientType: "account",
-      isActivityLogEnabled: false,
+      isActivityLogEnabled: true,
       isAvailableInWelsh: true,
       isHmrc: false,
       isReportSuspiciousActivityEnabled: false,


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

<!-- Describe the changes in detail - the "what"-->
Previously we had this list configured in the frontend for what would show in the activity history list.
```  ONE_LOGIN_HOME_NON_PROD,
  getOIDCClientId(),
  ...hmrcClientIds,
  ...getAllowedAccountListClientIDs,
  ...getAllowedServiceListClientIDs,
```

We then migrated to use the RP registry but it was identified that the flags were not configured correctly.
This update adds Accounts, Service, HRMC, and 'oneLoginHome'. 

### How to review
I'm uncertain on getOIDCClientId()