### PR TITLE
OLH-2765: update start page description for Connectivity Tool from the Department for Transport

### DIFF
--- a/clients/dftConnectivityTool.ts
+++ b/clients/dftConnectivityTool.ts
@@ -20,7 +20,7 @@ const dftConnectivityTool: Client = {
       linkText: "Go to your Connectivity Tool",
       linkUrl: "https://connectivity-tool.dft.gov.uk/",
       startUrl: "https://www.gov.uk/guidance/connectivity-tool",
-      startText: "Department for Transport Connectivity Tool",
+      startText: "Connectivity Tool from the Department for Transport",
     },
   },
   isOffboarded: false,


### PR DESCRIPTION
### What changed

Update start page description for Connectivity Tool from the Department for Transport