### PR TITLE
OLH-2921: add additional search terms

### DIFF
--- a/clients/dbs.ts
+++ b/clients/dbs.ts
@@ -20,7 +20,7 @@ const dbs: Client = {
       linkUrl: "https://www.gov.uk/request-copy-criminal-record",
       startUrl: "https://www.gov.uk/request-copy-criminal-record",
       startText: "Request a basic DBS check",
-      additionalSearchTerms: ["disclosure", "barring", "service"],
+      additionalSearchTerms: "disclosure barring service",
     },
     cy: {
       header: "Gwneud cais am wiriad DBS sylfaenol",
@@ -28,7 +28,7 @@ const dbs: Client = {
       linkUrl: "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol",
       startUrl: "https://www.gov.uk/gwneud-cais-copi-cofnod-troseddol",
       startText: "Gwneud cais am wiriad DBS sylfaenol",
-      keywords: ["disclosure", "barring", "service"],
+      additionalSearchTerms: "disclosure barring service",
     },
   },
   isOffboarded: false,

--- a/interfaces/client.interface.ts
+++ b/interfaces/client.interface.ts
@@ -16,7 +16,7 @@ interface Translations {
   paragraph2?: string;
   startUrl?: string;
   startText?: string;
-  additionalSearchTerms?: string[];
+  additionalSearchTerms?: string;
 }
 
 interface BaseClient {

--- a/interfaces/translations.interface.ts
+++ b/interfaces/translations.interface.ts
@@ -8,6 +8,7 @@ export interface Translation {
   paragraph2?: string;
   startText?: string;
   startUrl?: string;
+  additionalSearchTerms?: string;
 }
 
 export type TranslationsObject = Record<string, Translation>;

--- a/src/get-translations.ts
+++ b/src/get-translations.ts
@@ -24,6 +24,9 @@ const convertToTranslation = (
       ...(translations.paragraph2 && { paragraph2: translations.paragraph2 }),
       ...(translations.startText && { startText: translations.startText }),
       ...(translations.startUrl && { startUrl: translations.startUrl }),
+      ...(translations.additionalSearchTerms && {
+        additionalSearchTerms: translations.additionalSearchTerms,
+      }),
     };
   }
 };


### PR DESCRIPTION
### What changed

- Add a new optional translations property `additionalSearchTerms`.
- Add additional search terms to the DBS client

### Why did it change

So that "Request a basic DBS check" shows when searching for "disclosure barring service" (once frontend changes to use `additionalSearchTerms` have been implemented).