### PR TITLE
OLH-3110: extend boolean properties to allow dates

### DIFF
--- a/clients/hoSubmitAPleasureCraftReport.ts
+++ b/clients/hoSubmitAPleasureCraftReport.ts
@@ -13,7 +13,7 @@ const hoSubmitAPleasureCraftReport: Client = {
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: {
-    production: new Date("Wed, 10 Sep 2025 23:00:00 GMT"),
+    production: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
     nonProduction: true,
   },
   translations: {

--- a/clients/hoSubmitAPleasureCraftReport.ts
+++ b/clients/hoSubmitAPleasureCraftReport.ts
@@ -12,7 +12,10 @@ const hoSubmitAPleasureCraftReport: Client = {
   showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
-  showInSearchableList: true,
+  showInSearchableList: {
+    production: new Date("Wed, 10 Sep 2025 23:00:00 GMT"),
+    nonProduction: true,
+  },
   translations: {
     en: {
       header: "Submit a Pleasure Craft Report",

--- a/interfaces/client.interface.ts
+++ b/interfaces/client.interface.ts
@@ -19,6 +19,8 @@ interface Translations {
   additionalSearchTerms?: string;
 }
 
+export type BooleanOrDate = boolean | Date;
+
 interface BaseClient {
   clientId: EnvironmentValue<string>;
   translations?: {
@@ -26,13 +28,13 @@ interface BaseClient {
     cy?: Translations;
   };
   isAvailableInWelsh: boolean;
-  showInAccounts: boolean;
-  showInServices: boolean;
-  showDetailedCard: boolean;
-  showInActivityHistory: boolean;
-  showInSearchableList: EnvironmentValue<boolean>;
-  showInDeleteAccount: boolean;
-  isOffboarded: boolean;
+  showInAccounts: BooleanOrDate;
+  showInServices: BooleanOrDate;
+  showDetailedCard: BooleanOrDate;
+  showInActivityHistory: BooleanOrDate;
+  showInSearchableList: EnvironmentValue<BooleanOrDate>;
+  showInDeleteAccount: BooleanOrDate;
+  isOffboarded: BooleanOrDate;
 }
 
 export type Client = BaseClient;

--- a/src/filter-clients.ts
+++ b/src/filter-clients.ts
@@ -1,25 +1,19 @@
 import * as clients from "../clients";
-import { Client } from "../interfaces/client.interface";
 import { RegistryEntry } from "../interfaces/registry.interface";
-import { getValueForEnvironment, transformClientObject } from "./utils";
+import { transformClientObject } from "./utils";
 
 const filterClients = (
   environment: string,
-  filters: Partial<Client> = {}
+  filters: Partial<RegistryEntry> = {}
 ): RegistryEntry[] => {
   return Object.values(clients)
+    .filter((client) => client.clientId !== undefined)
+    .map((client) => transformClientObject(client, environment))
     .filter((client) => {
-      return (
-        client.clientId !== undefined &&
-        Object.entries(filters).every(([key, value]) => {
-          return (
-            getValueForEnvironment(environment, client[key as keyof Client]) ===
-            value
-          );
-        })
-      );
-    })
-    .map((client) => transformClientObject(client, environment));
+      return Object.entries(filters).every(([key, value]) => {
+        return client[key as keyof RegistryEntry] === value;
+      });
+    });
 };
 
 export default filterClients;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,8 @@
-import { Client, EnvironmentValue } from "../interfaces/client.interface";
+import {
+  BooleanOrDate,
+  Client,
+  EnvironmentValue,
+} from "../interfaces/client.interface";
 import { RegistryEntry } from "../interfaces/registry.interface";
 
 const isEnvironmentObject = <T>(
@@ -45,34 +49,40 @@ const getValueForEnvironment = <T>(
   return value.nonProduction;
 };
 
+export const booleanOrDateToBoolean = (value: BooleanOrDate) => {
+  return !(value instanceof Date) ? value : value <= new Date();
+};
+
 const transformClientObject = (
   client: Client,
   environment: string
 ): RegistryEntry => {
   return {
     clientId: getValueForEnvironment(environment, client.clientId),
-    showInAccounts: getValueForEnvironment(environment, client.showInAccounts),
-    showInServices: getValueForEnvironment(environment, client.showInServices),
-    isOffboarded: getValueForEnvironment(environment, client.isOffboarded),
-    showDetailedCard: getValueForEnvironment(
-      environment,
-      client.showDetailedCard
+    showInAccounts: booleanOrDateToBoolean(
+      getValueForEnvironment(environment, client.showInAccounts)
+    ),
+    showInServices: booleanOrDateToBoolean(
+      getValueForEnvironment(environment, client.showInServices)
+    ),
+    isOffboarded: booleanOrDateToBoolean(
+      getValueForEnvironment(environment, client.isOffboarded)
+    ),
+    showDetailedCard: booleanOrDateToBoolean(
+      getValueForEnvironment(environment, client.showDetailedCard)
     ),
     isAvailableInWelsh: getValueForEnvironment(
       environment,
       client.isAvailableInWelsh
     ),
-    showInSearchableList: getValueForEnvironment(
-      environment,
-      client.showInSearchableList
+    showInSearchableList: booleanOrDateToBoolean(
+      getValueForEnvironment(environment, client.showInSearchableList)
     ),
-    showInActivityHistory: getValueForEnvironment(
-      environment,
-      client.showInActivityHistory
+    showInActivityHistory: booleanOrDateToBoolean(
+      getValueForEnvironment(environment, client.showInActivityHistory)
     ),
-    showInDeleteAccount: getValueForEnvironment(
-      environment,
-      client.showInDeleteAccount
+    showInDeleteAccount: booleanOrDateToBoolean(
+      getValueForEnvironment(environment, client.showInDeleteAccount)
     ),
   };
 };

--- a/tests/filter-clients.test.ts
+++ b/tests/filter-clients.test.ts
@@ -1,4 +1,11 @@
-import { expect, test, describe, jest } from "@jest/globals";
+import {
+  expect,
+  test,
+  describe,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 import filterClients from "../src/filter-clients";
 
 jest.mock("../clients", () => ({
@@ -105,9 +112,63 @@ jest.mock("../clients", () => ({
     showInDeleteAccount: false,
     showInServices: false,
   },
+  datedClient1: {
+    isAvailableInWelsh: false,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+        description: "description en",
+      },
+    },
+    clientId: "datedClient1",
+    showInAccounts: new Date(2025, 7, 29),
+    showInServices: new Date(2025, 7, 29),
+    showDetailedCard: new Date(2025, 7, 29),
+    showInActivityHistory: new Date(2025, 7, 29),
+    showInDeleteAccount: new Date(2025, 7, 29),
+    showInSearchableList: {
+      production: new Date(2025, 7, 29),
+      nonProduction: false,
+    },
+    isOffboarded: new Date(2025, 7, 29),
+  },
+  datedClient2: {
+    isAvailableInWelsh: true,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+        description: "description en",
+      },
+    },
+    clientId: "datedClient2",
+    showInAccounts: new Date(2025, 7, 29),
+    showInServices: new Date(2025, 7, 29),
+    showDetailedCard: new Date(2025, 7, 29),
+    showInActivityHistory: new Date(2025, 7, 29),
+    showInDeleteAccount: new Date(2025, 7, 29),
+    showInSearchableList: {
+      production: new Date(2025, 7, 29),
+      nonProduction: true,
+    },
+    isOffboarded: new Date(2025, 7, 29),
+  },
 }));
 
 describe("filterClient", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(1970, 11, 31).getTime());
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
   test("should return the client objects that match the given criteria", () => {
     const client = filterClients("test", { showDetailedCard: true });
     expect(client).toEqual([
@@ -121,6 +182,45 @@ describe("filterClient", () => {
         showDetailedCard: true,
         showInSearchableList: false,
         isOffboarded: false,
+      },
+    ]);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const client2 = filterClients("test", { showDetailedCard: true });
+    expect(client2).toEqual([
+      {
+        clientId: "hmrcClient",
+        showInAccounts: true,
+        showInServices: false,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        isAvailableInWelsh: false,
+        showDetailedCard: true,
+        showInSearchableList: false,
+        isOffboarded: false,
+      },
+      {
+        clientId: "datedClient1",
+        showInAccounts: true,
+        showInServices: true,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        isAvailableInWelsh: false,
+        showDetailedCard: true,
+        showInSearchableList: false,
+        isOffboarded: true,
+      },
+      {
+        clientId: "datedClient2",
+        showInAccounts: true,
+        showInServices: true,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        isAvailableInWelsh: true,
+        showDetailedCard: true,
+        showInSearchableList: true,
+        isOffboarded: true,
       },
     ]);
   });
@@ -139,6 +239,47 @@ describe("filterClient", () => {
         showInSearchableList: true,
         isOffboarded: false,
       },
+      {
+        clientId: "datedClient2",
+        showInAccounts: false,
+        showInServices: false,
+        showInActivityHistory: false,
+        showInDeleteAccount: false,
+        isAvailableInWelsh: true,
+        showDetailedCard: false,
+        showInSearchableList: true,
+        isOffboarded: false,
+      },
+    ]);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const client2 = filterClients("nonProduction", {
+      isAvailableInWelsh: true,
+    });
+    expect(client2).toEqual([
+      {
+        clientId: "welshClientNonProd",
+        showInAccounts: true,
+        showInServices: false,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        isAvailableInWelsh: true,
+        showDetailedCard: false,
+        showInSearchableList: true,
+        isOffboarded: false,
+      },
+      {
+        clientId: "datedClient2",
+        showInAccounts: true,
+        showInServices: true,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        isAvailableInWelsh: true,
+        showDetailedCard: true,
+        showInSearchableList: true,
+        isOffboarded: true,
+      },
     ]);
   });
 
@@ -149,22 +290,47 @@ describe("filterClient", () => {
     const result2 = filterClients("nonProduction", {
       showInSearchableList: true,
     });
-    expect(result2).toHaveLength(2);
+    expect(result2).toHaveLength(3);
 
     const result3 = filterClients("production", {
       showInSearchableList: false,
     });
-    expect(result3).toHaveLength(2);
+    expect(result3).toHaveLength(4);
 
     const result4 = filterClients("nonProduction", {
       showInSearchableList: false,
     });
-    expect(result4).toHaveLength(3);
+    expect(result4).toHaveLength(4);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result5 = filterClients("production", { showInSearchableList: true });
+    expect(result5).toHaveLength(5);
+
+    const result6 = filterClients("nonProduction", {
+      showInSearchableList: true,
+    });
+    expect(result6).toHaveLength(3);
+
+    const result7 = filterClients("production", {
+      showInSearchableList: false,
+    });
+    expect(result7).toHaveLength(2);
+
+    const result8 = filterClients("nonProduction", {
+      showInSearchableList: false,
+    });
+    expect(result8).toHaveLength(4);
   });
 
   test("should work with boolean filters", () => {
     const result = filterClients("nonProduction", { showDetailedCard: true });
     expect(result).toHaveLength(1);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("nonProduction", { showDetailedCard: true });
+    expect(result2).toHaveLength(3);
   });
 
   test("should return clients matching multiple filters (showInAccounts: true, isOffboarded: false)", () => {
@@ -174,16 +340,35 @@ describe("filterClient", () => {
       isOffboarded: false,
     });
     expect(result).toHaveLength(3);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("production", {
+      showInAccounts: true,
+      showInServices: false,
+      isOffboarded: false,
+    });
+    expect(result2).toHaveLength(3);
   });
 
   test("should return empty array if no clients match the filters", () => {
     const result = filterClients("production", { clientId: "No Match" });
     expect(result).toEqual([]);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("production", { clientId: "No Match" });
+    expect(result2).toEqual([]);
   });
 
   test("should return all clients if no filters are provided", () => {
     const result = filterClients("production");
-    expect(result).toHaveLength(5);
+    expect(result).toHaveLength(7);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("production");
+    expect(result2).toHaveLength(7);
   });
 
   test("should correctly apply environment transformation for production", () => {
@@ -200,6 +385,46 @@ describe("filterClient", () => {
 
         showInSearchableList: true,
         isOffboarded: false,
+      },
+      {
+        clientId: "datedClient2",
+        isAvailableInWelsh: true,
+        isOffboarded: false,
+        showDetailedCard: false,
+        showInAccounts: false,
+        showInActivityHistory: false,
+        showInDeleteAccount: false,
+        showInSearchableList: false,
+        showInServices: false,
+      },
+    ]);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("production", { isAvailableInWelsh: true });
+    expect(result2).toEqual([
+      {
+        clientId: "welshClientProd",
+        showInAccounts: true,
+        showInServices: false,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        isAvailableInWelsh: true,
+        showDetailedCard: false,
+
+        showInSearchableList: true,
+        isOffboarded: false,
+      },
+      {
+        clientId: "datedClient2",
+        isAvailableInWelsh: true,
+        isOffboarded: true,
+        showDetailedCard: true,
+        showInAccounts: true,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        showInSearchableList: true,
+        showInServices: true,
       },
     ]);
   });
@@ -218,6 +443,47 @@ describe("filterClient", () => {
         showInSearchableList: true,
         isOffboarded: false,
       },
+      {
+        clientId: "datedClient2",
+        isAvailableInWelsh: true,
+        isOffboarded: false,
+        showDetailedCard: false,
+        showInAccounts: false,
+        showInActivityHistory: false,
+        showInDeleteAccount: false,
+        showInSearchableList: true,
+        showInServices: false,
+      },
+    ]);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("nonProduction", {
+      isAvailableInWelsh: true,
+    });
+    expect(result2).toEqual([
+      {
+        clientId: "welshClientNonProd",
+        showInAccounts: true,
+        showInServices: false,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        isAvailableInWelsh: true,
+        showDetailedCard: false,
+        showInSearchableList: true,
+        isOffboarded: false,
+      },
+      {
+        clientId: "datedClient2",
+        isAvailableInWelsh: true,
+        isOffboarded: true,
+        showDetailedCard: true,
+        showInAccounts: true,
+        showInActivityHistory: true,
+        showInDeleteAccount: true,
+        showInSearchableList: true,
+        showInServices: true,
+      },
     ]);
   });
 
@@ -226,10 +492,22 @@ describe("filterClient", () => {
       nonExistentKey: "someValue",
     } as any);
     expect(result).toEqual([]);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("production", {
+      nonExistentKey: "someValue",
+    } as any);
+    expect(result2).toEqual([]);
   });
 
   test("should correctly handle falsy values in filters", () => {
     const result = filterClients("production", { showDetailedCard: false });
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(6);
+
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    const result2 = filterClients("production", { showDetailedCard: false });
+    expect(result2).toHaveLength(4);
   });
 });

--- a/tests/get-client.test.ts
+++ b/tests/get-client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, jest } from "@jest/globals";
+import { expect, test, describe, jest, afterEach } from "@jest/globals";
 import getClient from "../src/get-client";
 
 jest.mock("../clients", () => ({
@@ -27,7 +27,6 @@ jest.mock("../clients", () => ({
     showInAccounts: true,
     showInServices: false,
     showDetailedCard: false,
-
     showInActivityHistory: true,
     showInDeleteAccount: true,
     showInSearchableList: true,
@@ -46,7 +45,6 @@ jest.mock("../clients", () => ({
     showInAccounts: true,
     showInServices: false,
     showDetailedCard: false,
-
     showInActivityHistory: true,
     showInDeleteAccount: true,
     showInSearchableList: true,
@@ -68,14 +66,62 @@ jest.mock("../clients", () => ({
     showInAccounts: true,
     showInServices: false,
     showDetailedCard: false,
-
     showInActivityHistory: true,
     showInDeleteAccount: true,
     showInSearchableList: true,
   },
+  datedClient1: {
+    isAvailableInWelsh: false,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+        description: "description en",
+      },
+    },
+    clientId: "datedClient1",
+    showInAccounts: new Date(2025, 7, 29),
+    showInServices: new Date(2025, 7, 29),
+    showDetailedCard: new Date(2025, 7, 29),
+    showInActivityHistory: new Date(2025, 7, 29),
+    showInDeleteAccount: new Date(2025, 7, 29),
+    showInSearchableList: {
+      production: new Date(2025, 7, 29),
+      nonProduction: false,
+    },
+    isOffboarded: new Date(2025, 7, 29),
+  },
+  datedClient2: {
+    isAvailableInWelsh: true,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+        description: "description en",
+      },
+    },
+    clientId: "datedClient2",
+    showInAccounts: new Date(2025, 7, 29),
+    showInServices: new Date(2025, 7, 29),
+    showDetailedCard: new Date(2025, 7, 29),
+    showInActivityHistory: new Date(2025, 7, 29),
+    showInDeleteAccount: new Date(2025, 7, 29),
+    showInSearchableList: {
+      production: new Date(2025, 7, 29),
+      nonProduction: true,
+    },
+    isOffboarded: new Date(2025, 7, 29),
+  },
 }));
 
 describe("getClient", () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
   test("should return the client object for the given clientId", () => {
     const client = getClient("test", "welshClientNonProd");
     expect(client).toEqual({
@@ -86,7 +132,6 @@ describe("getClient", () => {
       showInDeleteAccount: true,
       isAvailableInWelsh: true,
       showDetailedCard: false,
-
       showInSearchableList: true,
     });
   });
@@ -101,8 +146,65 @@ describe("getClient", () => {
       showInDeleteAccount: true,
       isAvailableInWelsh: true,
       showDetailedCard: false,
-
       showInSearchableList: true,
+    });
+  });
+
+  test("should return true for dated properties which are in the past", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2099, 11, 31).getTime());
+
+    expect(getClient("production", "datedClient1")).toEqual({
+      clientId: "datedClient1",
+      showInAccounts: true,
+      showInServices: true,
+      showInActivityHistory: true,
+      showInDeleteAccount: true,
+      isAvailableInWelsh: false,
+      showDetailedCard: true,
+      showInSearchableList: true,
+      isOffboarded: true,
+    });
+
+    expect(getClient("test", "datedClient1")).toEqual({
+      clientId: "datedClient1",
+      showInAccounts: true,
+      showInServices: true,
+      showInActivityHistory: true,
+      showInDeleteAccount: true,
+      isAvailableInWelsh: false,
+      showDetailedCard: true,
+      showInSearchableList: false,
+      isOffboarded: true,
+    });
+  });
+
+  test("should return false for dated properties which are in the future", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(1970, 0, 1).getTime());
+
+    expect(getClient("production", "datedClient2")).toEqual({
+      clientId: "datedClient2",
+      showInAccounts: false,
+      showInServices: false,
+      showInActivityHistory: false,
+      showInDeleteAccount: false,
+      isAvailableInWelsh: true,
+      showDetailedCard: false,
+      showInSearchableList: false,
+      isOffboarded: false,
+    });
+
+    expect(getClient("test", "datedClient2")).toEqual({
+      clientId: "datedClient2",
+      showInAccounts: false,
+      showInServices: false,
+      showInActivityHistory: false,
+      showInDeleteAccount: false,
+      isAvailableInWelsh: true,
+      showDetailedCard: false,
+      showInSearchableList: true,
+      isOffboarded: false,
     });
   });
 });

--- a/tests/get-client.test.ts
+++ b/tests/get-client.test.ts
@@ -114,6 +114,28 @@ jest.mock("../clients", () => ({
     },
     isOffboarded: new Date(2025, 7, 29),
   },
+  datedClient3: {
+    isAvailableInWelsh: true,
+    translations: {
+      en: {
+        header: "header en",
+        linkText: "link text en",
+        linkUrl: "link url en",
+        description: "description en",
+      },
+    },
+    clientId: "datedClient3",
+    showInAccounts: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
+    showInServices: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
+    showDetailedCard: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
+    showInActivityHistory: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
+    showInDeleteAccount: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
+    showInSearchableList: {
+      production: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
+      nonProduction: true,
+    },
+    isOffboarded: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
+  },
 }));
 
 describe("getClient", () => {
@@ -197,6 +219,61 @@ describe("getClient", () => {
 
     expect(getClient("test", "datedClient2")).toEqual({
       clientId: "datedClient2",
+      showInAccounts: false,
+      showInServices: false,
+      showInActivityHistory: false,
+      showInDeleteAccount: false,
+      isAvailableInWelsh: true,
+      showDetailedCard: false,
+      showInSearchableList: true,
+      isOffboarded: false,
+    });
+  });
+
+  test("should handle datetime offsets correctly", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("Wed, 10 Sep 2025 23:00:00 GMT").getTime());
+
+    expect(getClient("production", "datedClient3")).toEqual({
+      clientId: "datedClient3",
+      showInAccounts: true,
+      showInServices: true,
+      showInActivityHistory: true,
+      showInDeleteAccount: true,
+      isAvailableInWelsh: true,
+      showDetailedCard: true,
+      showInSearchableList: true,
+      isOffboarded: true,
+    });
+
+    expect(getClient("test", "datedClient3")).toEqual({
+      clientId: "datedClient3",
+      showInAccounts: true,
+      showInServices: true,
+      showInActivityHistory: true,
+      showInDeleteAccount: true,
+      isAvailableInWelsh: true,
+      showDetailedCard: true,
+      showInSearchableList: true,
+      isOffboarded: true,
+    });
+
+    jest.setSystemTime(new Date("Wed, 10 Sep 2025 22:00:00 GMT").getTime());
+
+    expect(getClient("production", "datedClient3")).toEqual({
+      clientId: "datedClient3",
+      showInAccounts: false,
+      showInServices: false,
+      showInActivityHistory: false,
+      showInDeleteAccount: false,
+      isAvailableInWelsh: true,
+      showDetailedCard: false,
+      showInSearchableList: false,
+      isOffboarded: false,
+    });
+
+    expect(getClient("test", "datedClient3")).toEqual({
+      clientId: "datedClient3",
       showInAccounts: false,
       showInServices: false,
       showInActivityHistory: false,

--- a/tests/validate-clients.test.ts
+++ b/tests/validate-clients.test.ts
@@ -13,13 +13,12 @@ describe("Client data validation", () => {
     const client = require(path.join(clientsDir, file)).default;
     describe(`${file}`, () => {
       describe("isAvailableInWelsh", () => {
-        test("should have welsh content if isAvailableInWelsh is true", () => {
+        test("should have Welsh content if isAvailableInWelsh is true", () => {
           if (client.isAvailableInWelsh) {
-            expect(client.translations).toBeDefined();
-            expect(client.translations.cy).toBeDefined();
+            expect(client.translations?.cy).toBeDefined();
           }
         });
-        test("should have isAvailableInWelsh true as Welsh content is available", () => {
+        test("isAvailableInWelsh should be true if Welsh content is available", () => {
           if (client.translations?.cy) {
             expect(client.isAvailableInWelsh).toBeTruthy();
           }
@@ -27,115 +26,142 @@ describe("Client data validation", () => {
       });
 
       describe("showInAccounts", () => {
-        test("should have header, linkText, linkUrl and description if showInAccounts is true", () => {
+        test("should have header, linkText, linkUrl and description if showInAccounts is not false", () => {
           if (client.showInAccounts) {
-            expect(client.translations.en.header).toBeDefined();
-            expect(client.translations.en.linkText).toBeDefined();
-            expect(client.translations.en.linkUrl).toBeDefined();
-            expect(client.translations.en.description).toBeDefined();
+            expect(client.translations?.en?.header).toBeDefined();
+            expect(client.translations?.en?.linkText).toBeDefined();
+            expect(client.translations?.en?.linkUrl).toBeDefined();
+            expect(client.translations?.en?.description).toBeDefined();
           }
         });
 
-        test("should have showInServices false and showInAccounts is true", () => {
+        test("showInServices should be false if showInAccounts is not false", () => {
           if (client.showInAccounts) {
             expect(client.showInServices).toBeFalsy();
           }
         });
 
-        test("should end description with a full stop", () => {
+        test("should have Welsh tranlations if showInAccounts is not false and isAvailableInWelsh is true", () => {
+          if (client.showInAccounts && client.isAvailableInWelsh) {
+            expect(client.translations?.cy?.header).toBeDefined();
+            expect(client.translations?.cy?.linkText).toBeDefined();
+            expect(client.translations?.cy?.linkUrl).toBeDefined();
+            expect(client.translations?.cy?.description).toBeDefined();
+          }
+        });
+
+        test("descriptions should end with a full stop", () => {
           if (client.showInAccounts) {
-            const description = client.translations.en.description;
-            expect(typeof description).toBe("string");
-            expect(description.trim().endsWith(".")).toBe(true);
-          }
-        });
+            expect(
+              client.translations?.en?.description.trim().endsWith(".")
+            ).toBe(true);
 
-        test("should have header, linkText, linkUrl and description in welsh showInAccounts is true", () => {
-          if (client.showInAccounts && client.isAvailableInWelsh) {
-            expect(client.translations.cy.header).toBeDefined();
-            expect(client.translations.cy.linkText).toBeDefined();
-            expect(client.translations.cy.linkUrl).toBeDefined();
-            expect(client.translations.cy.description).toBeDefined();
-          }
-        });
-
-        test("should end welsh description with a full stop", () => {
-          if (client.showInAccounts && client.isAvailableInWelsh) {
-            const description = client.translations.cy.description;
-            expect(typeof description).toBe("string");
-            expect(description.trim().endsWith(".")).toBe(true);
+            if (client.isAvailableInWelsh) {
+              expect(
+                client.translations?.cy?.description.trim().endsWith(".")
+              ).toBe(true);
+            }
           }
         });
       });
 
       describe("showInServices", () => {
-        test("should have header, linkText and linkUrl if showInServices is true", () => {
+        test("should have header, linkText and linkUrl if showInServices is not false", () => {
           if (client.showInServices) {
-            expect(client.translations.en.header).toBeDefined();
-            expect(client.translations.en.linkText).toBeDefined();
-            expect(client.translations.en.linkUrl).toBeDefined();
+            expect(client.translations?.en?.header).toBeDefined();
+            expect(client.translations?.en?.linkText).toBeDefined();
+            expect(client.translations?.en?.linkUrl).toBeDefined();
           }
         });
 
-        test("should have showInAccounts false and showInServices is true", () => {
+        test("showInAccounts should be false and showInServices is not false", () => {
           if (client.showInServices) {
             expect(client.showInAccounts).toBeFalsy();
           }
         });
 
-        test("should have welsh translation if available in welsh and showInServices is true", () => {
+        test("should have Welsh tranlations if showInServices is not false and isAvailableInWelsh is true", () => {
           if (client.showInServices && client.isAvailableInWelsh) {
-            expect(client.translations.cy.header).toBeDefined();
-            expect(client.translations.cy.linkText).toBeDefined();
-            expect(client.translations.cy.linkUrl).toBeDefined();
-          }
-        });
-
-        test("should not have description populated as it is a service, description is only used in accounts", () => {
-          if (client.showInServices) {
-            expect(client.translations.en.describe).toBeUndefined();
+            expect(client.translations?.cy?.header).toBeDefined();
+            expect(client.translations?.cy?.linkText).toBeDefined();
+            expect(client.translations?.cy?.linkUrl).toBeDefined();
           }
         });
       });
 
       describe("showDetailedCard", () => {
-        test("should have hintText, Pargraph1 and Paragrapgh2 if showDetailedCard is true", () => {
+        test("should have hintText, pargraph1 and paragrapgh2 if showDetailedCard is not false", () => {
           if (client.showDetailedCard) {
-            expect(client.translations.en.hintText).toBeDefined();
-            expect(client.translations.en.paragraph1).toBeDefined();
-            expect(client.translations.en.paragraph2).toBeDefined();
+            expect(client.translations?.en?.hintText).toBeDefined();
+            expect(client.translations?.en?.paragraph1).toBeDefined();
+            expect(client.translations?.en?.paragraph2).toBeDefined();
+          }
+        });
+
+        test("should have Welsh tranlations if showDetailedCard is not false and isAvailableInWelsh is true", () => {
+          if (client.showDetailedCard && client.isAvailableInWelsh) {
+            expect(client.translations?.cy?.hintText).toBeDefined();
+            expect(client.translations?.cy?.paragraph1).toBeDefined();
+            expect(client.translations?.cy?.paragraph2).toBeDefined();
           }
         });
       });
 
       describe("showInActivityHistory", () => {
-        test("should have header if showInActivityHistory is true", () => {
+        test("should have header if showInActivityHistory is not false", () => {
           if (client.showInActivityHistory) {
-            expect(client.translations.en.header).toBeDefined();
+            expect(client.translations?.en?.header).toBeDefined();
           }
         });
-        test("should have header in Welsh if showInActivityHistory is true and isAvailableInWelsh is true", () => {
+
+        test("should have Welsh tranlations if showInActivityHistory is not false and isAvailableInWelsh is true", () => {
           if (client.showInActivityHistory && client.isAvailableInWelsh) {
-            expect(client.translations.cy.header).toBeDefined();
+            expect(client.translations?.cy?.header).toBeDefined();
           }
         });
       });
 
       describe("showInSearchableList", () => {
-        test("should have startUrl and startText if showInSearchableList is true", () => {
-          if (client.showInSearchableList) {
-            expect(client.translations).toBeDefined();
-            expect(client.translations.en).toBeDefined();
-            expect(client.translations.en.startUrl).toBeTruthy();
-            expect(client.translations.en.startText).toBeTruthy();
+        test("should have startUrl and startText if showInSearchableList is not false", () => {
+          if (
+            typeof client.showInSearchableList === "object" &&
+            Object.prototype.hasOwnProperty.call(
+              client.showInSearchableList,
+              "production"
+            )
+          ) {
+            Object.values(client.showInSearchableList).forEach(
+              (showInSearchableList) => {
+                if (showInSearchableList) {
+                  expect(client.translations?.en?.startUrl).toBeDefined();
+                  expect(client.translations?.en?.startText).toBeDefined();
+                }
+              }
+            );
+          } else if (client.showInSearchableList) {
+            expect(client.translations?.en?.startUrl).toBeDefined();
+            expect(client.translations?.en?.startText).toBeDefined();
+          }
+        });
+
+        test("should have Welsh tranlations if showInSearchableList is not false and isAvailableInWelsh is true", () => {
+          if (client.showInSearchableList && client.isAvailableInWelsh) {
+            expect(client.translations?.cy?.startUrl).toBeDefined();
+            expect(client.translations?.cy?.startText).toBeDefined();
           }
         });
       });
 
       describe("showInDeleteAccount", () => {
-        test("should have header if showInDeleteAccount is true", () => {
+        test("should have header if showInDeleteAccount is not false", () => {
           if (client.showInDeleteAccount) {
-            expect(client.translations.en.header).toBeDefined();
+            expect(client.translations?.en?.header).toBeDefined();
+          }
+        });
+
+        test("should have Welsh tranlations if showInDeleteAccount is not false and isAvailableInWelsh is true", () => {
+          if (client.showInDeleteAccount && client.isAvailableInWelsh) {
+            expect(client.translations?.cy?.header).toBeDefined();
           }
         });
       });

--- a/tests/validate-clients.test.ts
+++ b/tests/validate-clients.test.ts
@@ -41,7 +41,7 @@ describe("Client data validation", () => {
           }
         });
 
-        test("should have Welsh tranlations if showInAccounts is not false and isAvailableInWelsh is true", () => {
+        test("should have Welsh translations if showInAccounts is not false and isAvailableInWelsh is true", () => {
           if (client.showInAccounts && client.isAvailableInWelsh) {
             expect(client.translations?.cy?.header).toBeDefined();
             expect(client.translations?.cy?.linkText).toBeDefined();
@@ -80,7 +80,7 @@ describe("Client data validation", () => {
           }
         });
 
-        test("should have Welsh tranlations if showInServices is not false and isAvailableInWelsh is true", () => {
+        test("should have Welsh translations if showInServices is not false and isAvailableInWelsh is true", () => {
           if (client.showInServices && client.isAvailableInWelsh) {
             expect(client.translations?.cy?.header).toBeDefined();
             expect(client.translations?.cy?.linkText).toBeDefined();
@@ -98,7 +98,7 @@ describe("Client data validation", () => {
           }
         });
 
-        test("should have Welsh tranlations if showDetailedCard is not false and isAvailableInWelsh is true", () => {
+        test("should have Welsh translations if showDetailedCard is not false and isAvailableInWelsh is true", () => {
           if (client.showDetailedCard && client.isAvailableInWelsh) {
             expect(client.translations?.cy?.hintText).toBeDefined();
             expect(client.translations?.cy?.paragraph1).toBeDefined();
@@ -114,7 +114,7 @@ describe("Client data validation", () => {
           }
         });
 
-        test("should have Welsh tranlations if showInActivityHistory is not false and isAvailableInWelsh is true", () => {
+        test("should have Welsh translations if showInActivityHistory is not false and isAvailableInWelsh is true", () => {
           if (client.showInActivityHistory && client.isAvailableInWelsh) {
             expect(client.translations?.cy?.header).toBeDefined();
           }
@@ -144,7 +144,7 @@ describe("Client data validation", () => {
           }
         });
 
-        test("should have Welsh tranlations if showInSearchableList is not false and isAvailableInWelsh is true", () => {
+        test("should have Welsh translations if showInSearchableList is not false and isAvailableInWelsh is true", () => {
           if (client.showInSearchableList && client.isAvailableInWelsh) {
             expect(client.translations?.cy?.startUrl).toBeDefined();
             expect(client.translations?.cy?.startText).toBeDefined();
@@ -159,7 +159,7 @@ describe("Client data validation", () => {
           }
         });
 
-        test("should have Welsh tranlations if showInDeleteAccount is not false and isAvailableInWelsh is true", () => {
+        test("should have Welsh translations if showInDeleteAccount is not false and isAvailableInWelsh is true", () => {
           if (client.showInDeleteAccount && client.isAvailableInWelsh) {
             expect(client.translations?.cy?.header).toBeDefined();
           }

--- a/tests/validate-clients.test.ts
+++ b/tests/validate-clients.test.ts
@@ -90,7 +90,7 @@ describe("Client data validation", () => {
       });
 
       describe("showDetailedCard", () => {
-        test("should have hintText, pargraph1 and paragrapgh2 if showDetailedCard is not false", () => {
+        test("should have hintText, paragraph1 and paragraph2 if showDetailedCard is not false", () => {
           if (client.showDetailedCard) {
             expect(client.translations?.en?.hintText).toBeDefined();
             expect(client.translations?.en?.paragraph1).toBeDefined();


### PR DESCRIPTION
### What changed

Updates the Client interface to allow certain boolean properties to also accept Date values. The functions for getting and filtering clients have been updated to handle clients with Date properties, and the associated unit tests have been updated to ensure it is working as expected.

### Why did it change

To allow us to merge client registry changes to production but not have certain features enabled until a particular date.