### PR TITLE
OLH-3817: Remove detailed card option from RP options

### DIFF
--- a/clients/CMAD.ts
+++ b/clients/CMAD.ts
@@ -9,7 +9,6 @@ const CMAD: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/PDPConnect.ts
+++ b/clients/PDPConnect.ts
@@ -9,7 +9,6 @@ const PDPConnect: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/UKSBS.ts
+++ b/clients/UKSBS.ts
@@ -9,7 +9,6 @@ const ukSBS: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/_testClient.ts
+++ b/clients/_testClient.ts
@@ -8,7 +8,6 @@ const aas: Client = {
   },
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: {

--- a/clients/aas.ts
+++ b/clients/aas.ts
@@ -8,7 +8,6 @@ const aas: Client = {
   },
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/adultSocialCare.ts
+++ b/clients/adultSocialCare.ts
@@ -9,7 +9,6 @@ const adultSocialCare: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/apar.ts
+++ b/clients/apar.ts
@@ -9,7 +9,6 @@ const apar: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/applyForMedal.ts
+++ b/clients/applyForMedal.ts
@@ -9,7 +9,6 @@ const applyForMedal: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/apprenticeshipsService.ts
+++ b/clients/apprenticeshipsService.ts
@@ -9,7 +9,6 @@ const apprenticeshipsService: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/ate.ts
+++ b/clients/ate.ts
@@ -9,7 +9,6 @@ const ate: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/checkFamilyEligibility.ts
+++ b/clients/checkFamilyEligibility.ts
@@ -9,7 +9,6 @@ const checkFamilyEligibility: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/childDevelopmentTraining.ts
+++ b/clients/childDevelopmentTraining.ts
@@ -9,7 +9,6 @@ const childDevelopmentTraining: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/coClientServiceJobs.ts
+++ b/clients/coClientServiceJobs.ts
@@ -9,7 +9,6 @@ const coClientServiceJobs: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/companyHouseAccounts.ts
+++ b/clients/companyHouseAccounts.ts
@@ -9,7 +9,6 @@ const companyHouseAccounts: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/connectFamilies.ts
+++ b/clients/connectFamilies.ts
@@ -9,7 +9,6 @@ const connectFamilies: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/criminalInjuriesCompensation.ts
+++ b/clients/criminalInjuriesCompensation.ts
@@ -9,7 +9,6 @@ const criminalInjuriesCompensation: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dbTrade.ts
+++ b/clients/dbTrade.ts
@@ -9,7 +9,6 @@ const dbTrade: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/dbs.ts
+++ b/clients/dbs.ts
@@ -9,7 +9,6 @@ const dbs: Client = {
   isAvailableInWelsh: true,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dbsSubmitABarringReferral.ts
+++ b/clients/dbsSubmitABarringReferral.ts
@@ -9,7 +9,6 @@ const dbsSubmitABarringReferral: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dbtApplyForAnExportCertificate.ts
+++ b/clients/dbtApplyForAnExportCertificate.ts
@@ -9,7 +9,6 @@ const dbtApplyForAnExportCertificate: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dbtApplyForAnImportLicense.ts
+++ b/clients/dbtApplyForAnImportLicense.ts
@@ -9,7 +9,6 @@ const dbtApplyForAnImportLicense: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dbtSubmitCosmeticProductNotification.ts
+++ b/clients/dbtSubmitCosmeticProductNotification.ts
@@ -9,7 +9,6 @@ const dbtSubmitCosmeticProductNotification: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dcmsShortTermLetsRegistrationService.ts
+++ b/clients/dcmsShortTermLetsRegistrationService.ts
@@ -9,7 +9,6 @@ const dcmsShortTermLetsRegistrationService: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/defraDangerousDogsIndex.ts
+++ b/clients/defraDangerousDogsIndex.ts
@@ -9,7 +9,6 @@ const defraDangerousDogsIndex: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/defraGioPlatform.ts
+++ b/clients/defraGioPlatform.ts
@@ -9,7 +9,6 @@ const defraGioPlatform: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/desnzFuelFinder.ts
+++ b/clients/desnzFuelFinder.ts
@@ -9,7 +9,6 @@ const desnzFuelFinder: Client = {
   isAvailableInWelsh: false,
   showInAccounts: new Date(2025, 11, 18),
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: new Date(2025, 11, 18),
   showInDeleteAccount: new Date(2025, 11, 18),
   showInSearchableList: new Date(2025, 11, 18),

--- a/clients/desnzHeatNetworkZoningPortal.ts
+++ b/clients/desnzHeatNetworkZoningPortal.ts
@@ -9,7 +9,6 @@ const desnzHeatNetworkZoningPortal: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/desnzManageEnergySavings.ts
+++ b/clients/desnzManageEnergySavings.ts
@@ -9,7 +9,6 @@ const desnzManageEnergySavings: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: {

--- a/clients/dfeAccessToYourTeachingQualifications.ts
+++ b/clients/dfeAccessToYourTeachingQualifications.ts
@@ -9,7 +9,6 @@ const dfeAccessToYourTeachingQualifications: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: {

--- a/clients/dfeApplyForTeacherTraining.ts
+++ b/clients/dfeApplyForTeacherTraining.ts
@@ -9,7 +9,6 @@ const dfeApplyForTeacherTraining: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dfeClaimAdditionalPaymentsEarlyYears.ts
+++ b/clients/dfeClaimAdditionalPaymentsEarlyYears.ts
@@ -9,7 +9,6 @@ const dfeClaimAdditionalPaymentsEarlyYears: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dfeFindAndUseAnApi.ts
+++ b/clients/dfeFindAndUseAnApi.ts
@@ -9,7 +9,6 @@ const dfeFindAndUseAnApi: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dfeFindTeacherTrainingCourses.ts
+++ b/clients/dfeFindTeacherTrainingCourses.ts
@@ -9,7 +9,6 @@ const dfeFindTeacherTrainingCourses: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dfeQualifiedTeacherStatus.ts
+++ b/clients/dfeQualifiedTeacherStatus.ts
@@ -9,7 +9,6 @@ const dfeQualifiedTeacherStatus: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dfeRetentionIncentives.ts
+++ b/clients/dfeRetentionIncentives.ts
@@ -9,7 +9,6 @@ const dfeRetentionIncentives: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dfeTeacherVacancies.ts
+++ b/clients/dfeTeacherVacancies.ts
@@ -9,7 +9,6 @@ const dfeTeacherVacancies: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dftConnectivityTool.ts
+++ b/clients/dftConnectivityTool.ts
@@ -9,7 +9,6 @@ const dftConnectivityTool: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dhscPmhcr.ts
+++ b/clients/dhscPmhcr.ts
@@ -9,7 +9,6 @@ const dhscPmhcr: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/drivingMedicalCondition.ts
+++ b/clients/drivingMedicalCondition.ts
@@ -9,7 +9,6 @@ const drivingMedicalCondition: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dvlaDriverAndVehiclesAccount.ts
+++ b/clients/dvlaDriverAndVehiclesAccount.ts
@@ -9,7 +9,6 @@ const dvlaDriverAndVehiclesAccount: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dwpAccessToWork.ts
+++ b/clients/dwpAccessToWork.ts
@@ -9,7 +9,6 @@ const dwpAccessToWork: Client = {
   isAvailableInWelsh: true,
   showInAccounts: new Date(2025, 10, 26),
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: new Date(2025, 10, 26),
   showInDeleteAccount: new Date(2025, 10, 26),
   showInSearchableList: new Date(2025, 10, 26),

--- a/clients/dwpBenefitOwed.ts
+++ b/clients/dwpBenefitOwed.ts
@@ -9,7 +9,6 @@ const dwpBenefitOwed: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/dwpFindYourPensions.ts
+++ b/clients/dwpFindYourPensions.ts
@@ -9,7 +9,6 @@ const dwpFindYourPensions: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/dwpJobsAndCareers.ts
+++ b/clients/dwpJobsAndCareers.ts
@@ -8,7 +8,6 @@ const dwpJobsAndCareers: Client = {
   },
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: {

--- a/clients/dwpManageMyStatePension.ts
+++ b/clients/dwpManageMyStatePension.ts
@@ -9,7 +9,6 @@ const dwpManageMyStatePension: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dwpManageYourBenefitsAndStatePension.ts
+++ b/clients/dwpManageYourBenefitsAndStatePension.ts
@@ -9,7 +9,6 @@ const dwpManageYourBenefitsAndStatePension: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/dwpPersonalIndependencePayment.ts
+++ b/clients/dwpPersonalIndependencePayment.ts
@@ -9,7 +9,6 @@ const dwpPersonalIndependencePayment: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/energyPerformanceOfBuildingsDataPlatform.ts
+++ b/clients/energyPerformanceOfBuildingsDataPlatform.ts
@@ -9,7 +9,6 @@ const energyPerformanceOfBuildingsDataPlatform: Client = {
   isAvailableInWelsh: false, 
   showInAccounts: true,  
   showInServices: false, 
-  showDetailedCard: false,
   showInActivityHistory: true, 
   showInDeleteAccount: true, 
   showInSearchableList: false, 

--- a/clients/faa.ts
+++ b/clients/faa.ts
@@ -9,7 +9,6 @@ const faa: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/findATender.ts
+++ b/clients/findATender.ts
@@ -9,7 +9,6 @@ const findATender: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/findAndApplyForAGrant.ts
+++ b/clients/findAndApplyForAGrant.ts
@@ -9,7 +9,6 @@ const findAndApplyForAGrant: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/firs.ts
+++ b/clients/firs.ts
@@ -9,7 +9,6 @@ const firs: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/gbis.ts
+++ b/clients/gbis.ts
@@ -9,7 +9,6 @@ const gbis: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/govuk.ts
+++ b/clients/govuk.ts
@@ -9,7 +9,6 @@ const govuk: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/govukApp.ts
+++ b/clients/govukApp.ts
@@ -9,7 +9,6 @@ const govukApp: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/heatNetworkZoning.ts
+++ b/clients/heatNetworkZoning.ts
@@ -9,7 +9,6 @@ const heatNetworkZoning: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/hmctsDtsLegacyGenderRecognition.ts
+++ b/clients/hmctsDtsLegacyGenderRecognition.ts
@@ -9,7 +9,6 @@ const hmctsDtsLegacyGenderRecognition: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/hmpoCancelPassport.ts
+++ b/clients/hmpoCancelPassport.ts
@@ -9,7 +9,6 @@ const hmpoCancelPassport: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/hmrc.ts
+++ b/clients/hmrc.ts
@@ -9,7 +9,6 @@ const hmrc: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/hmrcGovernmentGateway.ts
+++ b/clients/hmrcGovernmentGateway.ts
@@ -9,7 +9,6 @@ const hmrcGovernmentGateway: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/hoDORS.ts
+++ b/clients/hoDORS.ts
@@ -9,7 +9,6 @@ const hoDORS: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/hoMyPolicePortal.ts
+++ b/clients/hoMyPolicePortal.ts
@@ -9,7 +9,6 @@ const hoMyPolicePortal: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/hoOnlineApis.ts
+++ b/clients/hoOnlineApis.ts
@@ -9,7 +9,6 @@ const hoOnlineApis: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/hoSubmitAPleasureCraftReport.ts
+++ b/clients/hoSubmitAPleasureCraftReport.ts
@@ -9,7 +9,6 @@ const hoSubmitAPleasureCraftReport: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: {

--- a/clients/hoSubmitGeneralAviationReport.ts
+++ b/clients/hoSubmitGeneralAviationReport.ts
@@ -9,7 +9,6 @@ const hoSubmitGeneralAviationReport: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/homeOfficeSEAS.ts
+++ b/clients/homeOfficeSEAS.ts
@@ -9,7 +9,6 @@ const homeOfficeSEAS: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/iaa.ts
+++ b/clients/iaa.ts
@@ -9,7 +9,6 @@ const iaa: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/icsDesnz.ts
+++ b/clients/icsDesnz.ts
@@ -9,7 +9,6 @@ const icsDesnz: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/icsDigitalPrsExemptions.ts
+++ b/clients/icsDigitalPrsExemptions.ts
@@ -9,7 +9,6 @@ const icsDigitalPrsExemptions: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/infectedBloodCompensationAuthority.ts
+++ b/clients/infectedBloodCompensationAuthority.ts
@@ -8,7 +8,6 @@ const icba: Client = {
   },
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/intellectualPropertyOffice.ts
+++ b/clients/intellectualPropertyOffice.ts
@@ -9,7 +9,6 @@ const intellectualPropertyOffice: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/ipvReturn.ts
+++ b/clients/ipvReturn.ts
@@ -9,7 +9,6 @@ const ipvReturn: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/jointNatureConservationCommitteeAirPollutionAssessment.ts
+++ b/clients/jointNatureConservationCommitteeAirPollutionAssessment.ts
@@ -8,7 +8,6 @@ const jointNatureConservationCommitteeAirPollutionAssessment: Client = {
   },
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/lite.ts
+++ b/clients/lite.ts
@@ -9,7 +9,6 @@ const lite: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/manageFamilySupport.ts
+++ b/clients/manageFamilySupport.ts
@@ -9,7 +9,6 @@ const manageFamilySupport: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/modHham.ts
+++ b/clients/modHham.ts
@@ -9,7 +9,6 @@ const modHham: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/modHhrp.ts
+++ b/clients/modHhrp.ts
@@ -9,7 +9,6 @@ const modHhrp: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/modSupplierCyberProtection.ts
+++ b/clients/modSupplierCyberProtection.ts
@@ -9,7 +9,6 @@ const modSupplierCyberProtection: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/modernSlavery.ts
+++ b/clients/modernSlavery.ts
@@ -9,7 +9,6 @@ const modernSlavery: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/mojPensionRelief.ts
+++ b/clients/mojPensionRelief.ts
@@ -11,7 +11,6 @@ const mojPensionRelief: Client = {
   },
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/mojPlanYourFuture.ts
+++ b/clients/mojPlanYourFuture.ts
@@ -9,7 +9,6 @@ const mojPlanYourFuture: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/mojVictimsPathFinderToDAP.ts
+++ b/clients/mojVictimsPathFinderToDAP.ts
@@ -9,7 +9,6 @@ const mojVictimsPathFinderToDAP: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/mortgageDeed.ts
+++ b/clients/mortgageDeed.ts
@@ -9,7 +9,6 @@ const mortgageDeed: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/nationalSecurityAndInvestments.ts
+++ b/clients/nationalSecurityAndInvestments.ts
@@ -9,7 +9,6 @@ const nationalSecurityAndInvestments: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/ofgemFinancialResilience.ts
+++ b/clients/ofgemFinancialResilience.ts
@@ -9,7 +9,6 @@ const ofgemFinancialResilience: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/ofgemHeatNetworks.ts
+++ b/clients/ofgemHeatNetworks.ts
@@ -9,7 +9,6 @@ const ofgemHeatNetworks: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/ofgemLafReg.ts
+++ b/clients/ofgemLafReg.ts
@@ -9,7 +9,6 @@ const ofgemLafReg: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/ofqual.ts
+++ b/clients/ofqual.ts
@@ -9,7 +9,6 @@ const ofqual: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/oneLoginHome.ts
+++ b/clients/oneLoginHome.ts
@@ -9,7 +9,6 @@ const oneLoginHome: Client = {
   isAvailableInWelsh: true,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/prisonVisits.ts
+++ b/clients/prisonVisits.ts
@@ -9,7 +9,6 @@ const prisonVisits: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: false,

--- a/clients/productSafetyDatabase.ts
+++ b/clients/productSafetyDatabase.ts
@@ -9,7 +9,6 @@ const productSafetyDatabase: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/relyingPartyStub.ts
+++ b/clients/relyingPartyStub.ts
@@ -9,7 +9,6 @@ const relyingPartyStub: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/ruralPaymentWales.ts
+++ b/clients/ruralPaymentWales.ts
@@ -9,7 +9,6 @@ const ruralPaymentWales: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/securityTokenService.ts
+++ b/clients/securityTokenService.ts
@@ -9,7 +9,6 @@ const securityTokenService: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/clients/smokeTests.ts
+++ b/clients/smokeTests.ts
@@ -9,7 +9,6 @@ const smokeTests: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
 
   showInActivityHistory: false,
   showInDeleteAccount: false,

--- a/clients/socialWorkEngland.ts
+++ b/clients/socialWorkEngland.ts
@@ -9,7 +9,6 @@ const socialWorkEngland: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/treeFellingLicence.ts
+++ b/clients/treeFellingLicence.ts
@@ -9,7 +9,6 @@ const treeFellingLicence: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/ukmcab.ts
+++ b/clients/ukmcab.ts
@@ -9,7 +9,6 @@ const ukmcab: Client = {
   isAvailableInWelsh: false,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/useLastingPowerOfAttorney.ts
+++ b/clients/useLastingPowerOfAttorney.ts
@@ -9,7 +9,6 @@ const useLastingPowerOfAttorney: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/vehicleOperatorLicense.ts
+++ b/clients/vehicleOperatorLicense.ts
@@ -9,7 +9,6 @@ const vehicleOperatorLicense: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/veteransCard.ts
+++ b/clients/veteransCard.ts
@@ -9,7 +9,6 @@ const veteransCard: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: true,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/welshFisheriesPermit.ts
+++ b/clients/welshFisheriesPermit.ts
@@ -9,7 +9,6 @@ const welshFisheriesPermit: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/welshGovChildcareOfferForWalesParents.ts
+++ b/clients/welshGovChildcareOfferForWalesParents.ts
@@ -9,7 +9,6 @@ const welshGovChildcareOfferForWalesParents: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/welshGovChildcareOfferForWalesProviders.ts
+++ b/clients/welshGovChildcareOfferForWalesProviders.ts
@@ -9,7 +9,6 @@ const welshGovChildcareOfferForWalesProviders: Client = {
   isAvailableInWelsh: true,
   showInAccounts: true,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: true,
   showInDeleteAccount: true,
   showInSearchableList: true,

--- a/clients/welshGovFarmingConnect.ts
+++ b/clients/welshGovFarmingConnect.ts
@@ -9,7 +9,6 @@ const welshGovFarmingConnect: Client = {
   isAvailableInWelsh: false,
   showInAccounts: false,
   showInServices: false,
-  showDetailedCard: false,
   showInActivityHistory: false,
   showInDeleteAccount: false,
   showInSearchableList: false,

--- a/interfaces/client.interface.ts
+++ b/interfaces/client.interface.ts
@@ -12,8 +12,6 @@ export interface ClientTranslations {
   linkText?: string;
   linkUrl?: EnvironmentValue<string>;
   hintText?: string;
-  paragraph1?: string;
-  paragraph2?: string;
   startUrl?: string;
   startText?: string;
   additionalSearchTerms?: string;
@@ -30,7 +28,6 @@ interface BaseClient {
   isAvailableInWelsh: boolean;
   showInAccounts: BooleanOrDate;
   showInServices: BooleanOrDate;
-  showDetailedCard: BooleanOrDate;
   showInActivityHistory: BooleanOrDate;
   showInSearchableList: EnvironmentValue<BooleanOrDate>;
   showInDeleteAccount: BooleanOrDate;

--- a/interfaces/registry.interface.ts
+++ b/interfaces/registry.interface.ts
@@ -5,7 +5,6 @@ export interface RegistryEntry {
   isAvailableInWelsh: boolean;
   showInAccounts: boolean;
   showInServices: boolean;
-  showDetailedCard: boolean;
   showInActivityHistory: boolean;
   showInSearchableList: boolean;
   showInDeleteAccount: boolean;

--- a/interfaces/translations.interface.ts
+++ b/interfaces/translations.interface.ts
@@ -4,8 +4,6 @@ export interface Translation {
   linkText?: string;
   linkUrl?: string;
   hintText?: string;
-  paragraph1?: string;
-  paragraph2?: string;
   startText?: string;
   startUrl?: string;
   additionalSearchTerms?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,9 +70,6 @@ const transformClientObject = (
     isOffboarded: booleanOrDateToBoolean(
       getValueForEnvironment(environment, client.isOffboarded)
     ),
-    showDetailedCard: booleanOrDateToBoolean(
-      getValueForEnvironment(environment, client.showDetailedCard)
-    ),
     isAvailableInWelsh: getValueForEnvironment(
       environment,
       client.isAvailableInWelsh
@@ -110,8 +107,6 @@ export const convertToTranslation = (
           description: translations.description,
         }),
         ...(translations.hintText && { hintText: translations.hintText }),
-        ...(translations.paragraph1 && { paragraph1: translations.paragraph1 }),
-        ...(translations.paragraph2 && { paragraph2: translations.paragraph2 }),
         ...(translations.startText && { startText: translations.startText }),
         ...(translations.startUrl && { startUrl: translations.startUrl }),
         ...(translations.additionalSearchTerms && {

--- a/tests/filter-clients.test.ts
+++ b/tests/filter-clients.test.ts
@@ -32,7 +32,6 @@ jest.mock("../clients", () => ({
       nonProduction: "welshClientNonProd",
     },
     showInAccounts: true,
-    showDetailedCard: false,
     showInActivityHistory: true,
     showInSearchableList: { production: true, nonProduction: true },
     isOffboarded: false,
@@ -51,7 +50,6 @@ jest.mock("../clients", () => ({
     },
     clientId: "englishClient",
     showInAccounts: true,
-    showDetailedCard: false,
     showInActivityHistory: true,
     showInSearchableList: { production: true, nonProduction: false },
     isOffboarded: false,
@@ -67,13 +65,10 @@ jest.mock("../clients", () => ({
         linkUrl: "link url en",
         description: "description en",
         hintText: "hint text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     },
     clientId: "hmrcClient",
     showInAccounts: true,
-    showDetailedCard: true,
     showInActivityHistory: true,
     showInSearchableList: { production: true, nonProduction: false },
     isOffboarded: false,
@@ -84,7 +79,6 @@ jest.mock("../clients", () => ({
     isAvailableInWelsh: false,
     clientId: "internalClient",
     clientType: "internal",
-    showDetailedCard: false,
     showInActivityHistory: true,
     showInSearchableList: { production: false, nonProduction: true },
     showInDeleteAccount: false,
@@ -99,13 +93,10 @@ jest.mock("../clients", () => ({
         linkUrl: "link url en",
         description: "description en",
         hintText: "hint text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     },
     clientId: "offboardedClient",
     showInAccounts: true,
-    showDetailedCard: false,
     showInActivityHistory: true,
     showInSearchableList: false,
     isOffboarded: true,
@@ -125,7 +116,6 @@ jest.mock("../clients", () => ({
     clientId: "datedClient1",
     showInAccounts: new Date(2025, 7, 29),
     showInServices: new Date(2025, 7, 29),
-    showDetailedCard: new Date(2025, 7, 29),
     showInActivityHistory: new Date(2025, 7, 29),
     showInDeleteAccount: new Date(2025, 7, 29),
     showInSearchableList: {
@@ -147,7 +137,6 @@ jest.mock("../clients", () => ({
     clientId: "datedClient2",
     showInAccounts: new Date(2025, 7, 29),
     showInServices: new Date(2025, 7, 29),
-    showDetailedCard: new Date(2025, 7, 29),
     showInActivityHistory: new Date(2025, 7, 29),
     showInDeleteAccount: new Date(2025, 7, 29),
     showInSearchableList: {
@@ -170,8 +159,18 @@ describe("filterClient", () => {
   });
 
   test("should return the client objects that match the given criteria", () => {
-    const client = filterClients("test", { showDetailedCard: true });
+    const client = filterClients("test", { showInDeleteAccount: true });
     expect(client).toEqual([
+      {
+         clientId: "welshClientNonProd",
+         isAvailableInWelsh: true,
+         isOffboarded: false,
+         showInAccounts: true,
+         showInActivityHistory: true,
+         showInDeleteAccount: true,
+         showInSearchableList: true,
+         showInServices: false,
+      },
       {
         clientId: "hmrcClient",
         showInAccounts: true,
@@ -179,7 +178,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: false,
-        showDetailedCard: true,
         showInSearchableList: false,
         isOffboarded: false,
       },
@@ -187,8 +185,18 @@ describe("filterClient", () => {
 
     jest.setSystemTime(new Date(2099, 11, 31).getTime());
 
-    const client2 = filterClients("test", { showDetailedCard: true });
+    const client2 = filterClients("test", { showInDeleteAccount: true });
     expect(client2).toEqual([
+      {
+         clientId: "welshClientNonProd",
+         isAvailableInWelsh: true,
+         isOffboarded: false,
+         showInAccounts: true,
+         showInActivityHistory: true,
+         showInDeleteAccount: true,
+         showInSearchableList: true,
+         showInServices: false,
+      },
       {
         clientId: "hmrcClient",
         showInAccounts: true,
@@ -196,7 +204,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: false,
-        showDetailedCard: true,
         showInSearchableList: false,
         isOffboarded: false,
       },
@@ -207,7 +214,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: false,
-        showDetailedCard: true,
         showInSearchableList: false,
         isOffboarded: true,
       },
@@ -218,7 +224,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: true,
         showInSearchableList: true,
         isOffboarded: true,
       },
@@ -235,7 +240,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: false,
         showInSearchableList: true,
         isOffboarded: false,
       },
@@ -246,7 +250,6 @@ describe("filterClient", () => {
         showInActivityHistory: false,
         showInDeleteAccount: false,
         isAvailableInWelsh: true,
-        showDetailedCard: false,
         showInSearchableList: true,
         isOffboarded: false,
       },
@@ -265,7 +268,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: false,
         showInSearchableList: true,
         isOffboarded: false,
       },
@@ -276,7 +278,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: true,
         showInSearchableList: true,
         isOffboarded: true,
       },
@@ -321,16 +322,6 @@ describe("filterClient", () => {
       showInSearchableList: false,
     });
     expect(result8).toHaveLength(4);
-  });
-
-  test("should work with boolean filters", () => {
-    const result = filterClients("nonProduction", { showDetailedCard: true });
-    expect(result).toHaveLength(1);
-
-    jest.setSystemTime(new Date(2099, 11, 31).getTime());
-
-    const result2 = filterClients("nonProduction", { showDetailedCard: true });
-    expect(result2).toHaveLength(3);
   });
 
   test("should return clients matching multiple filters (showInAccounts: true, isOffboarded: false)", () => {
@@ -381,8 +372,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: false,
-
         showInSearchableList: true,
         isOffboarded: false,
       },
@@ -390,7 +379,6 @@ describe("filterClient", () => {
         clientId: "datedClient2",
         isAvailableInWelsh: true,
         isOffboarded: false,
-        showDetailedCard: false,
         showInAccounts: false,
         showInActivityHistory: false,
         showInDeleteAccount: false,
@@ -410,8 +398,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: false,
-
         showInSearchableList: true,
         isOffboarded: false,
       },
@@ -419,7 +405,6 @@ describe("filterClient", () => {
         clientId: "datedClient2",
         isAvailableInWelsh: true,
         isOffboarded: true,
-        showDetailedCard: true,
         showInAccounts: true,
         showInActivityHistory: true,
         showInDeleteAccount: true,
@@ -439,7 +424,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: false,
         showInSearchableList: true,
         isOffboarded: false,
       },
@@ -447,7 +431,6 @@ describe("filterClient", () => {
         clientId: "datedClient2",
         isAvailableInWelsh: true,
         isOffboarded: false,
-        showDetailedCard: false,
         showInAccounts: false,
         showInActivityHistory: false,
         showInDeleteAccount: false,
@@ -469,7 +452,6 @@ describe("filterClient", () => {
         showInActivityHistory: true,
         showInDeleteAccount: true,
         isAvailableInWelsh: true,
-        showDetailedCard: false,
         showInSearchableList: true,
         isOffboarded: false,
       },
@@ -477,7 +459,6 @@ describe("filterClient", () => {
         clientId: "datedClient2",
         isAvailableInWelsh: true,
         isOffboarded: true,
-        showDetailedCard: true,
         showInAccounts: true,
         showInActivityHistory: true,
         showInDeleteAccount: true,
@@ -502,12 +483,12 @@ describe("filterClient", () => {
   });
 
   test("should correctly handle falsy values in filters", () => {
-    const result = filterClients("production", { showDetailedCard: false });
-    expect(result).toHaveLength(6);
+    const result = filterClients("production", { showInSearchableList: false });
+    expect(result).toHaveLength(4);
 
     jest.setSystemTime(new Date(2099, 11, 31).getTime());
 
-    const result2 = filterClients("production", { showDetailedCard: false });
-    expect(result2).toHaveLength(4);
+    const result2 = filterClients("production", { showInSearchableList: false });
+    expect(result2).toHaveLength(2);
   });
 });

--- a/tests/get-client.test.ts
+++ b/tests/get-client.test.ts
@@ -26,7 +26,6 @@ jest.mock("../clients", () => ({
     },
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
     showInActivityHistory: true,
     showInDeleteAccount: true,
     showInSearchableList: true,
@@ -44,7 +43,6 @@ jest.mock("../clients", () => ({
     clientId: "englishClient",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
     showInActivityHistory: true,
     showInDeleteAccount: true,
     showInSearchableList: true,
@@ -58,14 +56,11 @@ jest.mock("../clients", () => ({
         linkUrl: "link url en",
         description: "description en",
         hintText: "hint text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     },
     clientId: "englishClient",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
     showInActivityHistory: true,
     showInDeleteAccount: true,
     showInSearchableList: true,
@@ -83,7 +78,6 @@ jest.mock("../clients", () => ({
     clientId: "datedClient1",
     showInAccounts: new Date(2025, 7, 29),
     showInServices: new Date(2025, 7, 29),
-    showDetailedCard: new Date(2025, 7, 29),
     showInActivityHistory: new Date(2025, 7, 29),
     showInDeleteAccount: new Date(2025, 7, 29),
     showInSearchableList: {
@@ -105,7 +99,6 @@ jest.mock("../clients", () => ({
     clientId: "datedClient2",
     showInAccounts: new Date(2025, 7, 29),
     showInServices: new Date(2025, 7, 29),
-    showDetailedCard: new Date(2025, 7, 29),
     showInActivityHistory: new Date(2025, 7, 29),
     showInDeleteAccount: new Date(2025, 7, 29),
     showInSearchableList: {
@@ -127,7 +120,6 @@ jest.mock("../clients", () => ({
     clientId: "datedClient3",
     showInAccounts: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
     showInServices: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
-    showDetailedCard: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
     showInActivityHistory: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
     showInDeleteAccount: new Date("Wed, 11 Sep 2025 00:00:00 GMT+1"),
     showInSearchableList: {
@@ -153,7 +145,6 @@ describe("getClient", () => {
       showInActivityHistory: true,
       showInDeleteAccount: true,
       isAvailableInWelsh: true,
-      showDetailedCard: false,
       showInSearchableList: true,
     });
   });
@@ -167,7 +158,6 @@ describe("getClient", () => {
       showInActivityHistory: true,
       showInDeleteAccount: true,
       isAvailableInWelsh: true,
-      showDetailedCard: false,
       showInSearchableList: true,
     });
   });
@@ -183,7 +173,6 @@ describe("getClient", () => {
       showInActivityHistory: true,
       showInDeleteAccount: true,
       isAvailableInWelsh: false,
-      showDetailedCard: true,
       showInSearchableList: true,
       isOffboarded: true,
     });
@@ -195,7 +184,6 @@ describe("getClient", () => {
       showInActivityHistory: true,
       showInDeleteAccount: true,
       isAvailableInWelsh: false,
-      showDetailedCard: true,
       showInSearchableList: false,
       isOffboarded: true,
     });
@@ -212,7 +200,6 @@ describe("getClient", () => {
       showInActivityHistory: false,
       showInDeleteAccount: false,
       isAvailableInWelsh: true,
-      showDetailedCard: false,
       showInSearchableList: false,
       isOffboarded: false,
     });
@@ -224,7 +211,6 @@ describe("getClient", () => {
       showInActivityHistory: false,
       showInDeleteAccount: false,
       isAvailableInWelsh: true,
-      showDetailedCard: false,
       showInSearchableList: true,
       isOffboarded: false,
     });
@@ -241,7 +227,6 @@ describe("getClient", () => {
       showInActivityHistory: true,
       showInDeleteAccount: true,
       isAvailableInWelsh: true,
-      showDetailedCard: true,
       showInSearchableList: true,
       isOffboarded: true,
     });
@@ -253,7 +238,6 @@ describe("getClient", () => {
       showInActivityHistory: true,
       showInDeleteAccount: true,
       isAvailableInWelsh: true,
-      showDetailedCard: true,
       showInSearchableList: true,
       isOffboarded: true,
     });
@@ -267,7 +251,6 @@ describe("getClient", () => {
       showInActivityHistory: false,
       showInDeleteAccount: false,
       isAvailableInWelsh: true,
-      showDetailedCard: false,
       showInSearchableList: false,
       isOffboarded: false,
     });
@@ -279,7 +262,6 @@ describe("getClient", () => {
       showInActivityHistory: false,
       showInDeleteAccount: false,
       isAvailableInWelsh: true,
-      showDetailedCard: false,
       showInSearchableList: true,
       isOffboarded: false,
     });

--- a/tests/get-clientIds.test.ts
+++ b/tests/get-clientIds.test.ts
@@ -23,8 +23,6 @@ jest.mock("../clients", () => ({
     clientId: "welshClient",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
-
     showInSearchableList: true,
   },
   enClient: {
@@ -40,8 +38,6 @@ jest.mock("../clients", () => ({
     clientId: "englishClient",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
-
     showInSearchableList: true,
   },
   hmrcClient: {
@@ -53,15 +49,11 @@ jest.mock("../clients", () => ({
         linkUrl: "link url en",
         description: "description en",
         hintText: "hint text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     },
     clientId: "englishClientHmrc",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
-
     showInSearchableList: true,
   },
 }));

--- a/tests/get-translations.test.ts
+++ b/tests/get-translations.test.ts
@@ -23,8 +23,6 @@ jest.mock("../clients", () => ({
     clientId: "welshClient",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
-
     showInSearchableList: true,
   },
   enClient: {
@@ -40,8 +38,6 @@ jest.mock("../clients", () => ({
     clientId: "englishClient",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
-
     showInSearchableList: true,
   },
   hmrcClient: {
@@ -53,15 +49,11 @@ jest.mock("../clients", () => ({
         linkUrl: "link url en",
         description: "description en",
         hintText: "hint text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     },
     clientId: "englishClientHmrc",
     showInAccounts: true,
     showInServices: false,
-    showDetailedCard: false,
-
     showInSearchableList: true,
   },
   internalClient: {
@@ -71,8 +63,6 @@ jest.mock("../clients", () => ({
     },
     clientId: "internalClient",
     clientType: "internal",
-    showDetailedCard: false,
-
     showInSearchableList: false,
   },
 }));
@@ -98,8 +88,6 @@ describe("getTranslations", () => {
         hintText: "hint text en",
         linkUrl: "link url en",
         linkText: "link text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     });
   });
@@ -123,8 +111,6 @@ describe("getTranslations", () => {
         hintText: "hint text en",
         linkUrl: "link url en",
         linkText: "link text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     });
   });
@@ -148,8 +134,6 @@ describe("getTranslations", () => {
         hintText: "hint text en",
         linkUrl: "link url en",
         linkText: "link text en",
-        paragraph1: "paragraph 1 en",
-        paragraph2: "paragraph 2 en",
       },
     });
   });

--- a/tests/validate-clients.test.ts
+++ b/tests/validate-clients.test.ts
@@ -119,24 +119,6 @@ describe("Client data validation", () => {
         });
       });
 
-      describe("showDetailedCard", () => {
-        test("should have hintText, paragraph1 and paragraph2 if showDetailedCard is not false", () => {
-          if (client.showDetailedCard) {
-            expect(client.translations?.en?.hintText).toBeDefined();
-            expect(client.translations?.en?.paragraph1).toBeDefined();
-            expect(client.translations?.en?.paragraph2).toBeDefined();
-          }
-        });
-
-        test("should have Welsh translations if showDetailedCard is not false and isAvailableInWelsh is true", () => {
-          if (client.showDetailedCard && client.isAvailableInWelsh) {
-            expect(client.translations?.cy?.hintText).toBeDefined();
-            expect(client.translations?.cy?.paragraph1).toBeDefined();
-            expect(client.translations?.cy?.paragraph2).toBeDefined();
-          }
-        });
-      });
-
       describe("showInActivityHistory", () => {
         test("should have header if showInActivityHistory is not false", () => {
           if (client.showInActivityHistory) {


### PR DESCRIPTION


## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed
Remove `showDetailedCard` setting from clients. 
Corresponding PR on the frontend: https://github.com/govuk-one-login/di-account-management-frontend/pull/2973 

<!-- Describe the changes in detail - the "what"-->

### Why did it change

The `showDetailedCard` option was previously introduced with the purpose of displaying a richer service card for the HMRC service, in order to be able to communicate more clearly what the card represented. 

This is no longer a requirement now, as the design for the HMRC card has evolved to be the same as every other service. The purpose of this is to remove support for `showDetailedCard` across the RP registry.

<!-- Describe the reason these changes were made - the "why" -->


## How to review
Sense check this looks right and there is no code I've accidentally missed in refactoring.
<!-- Provide a summary of any testing you've done -->
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
