### PR TITLE
OLH-3888: Onboard DFE Apprenticeship service

### DIFF
--- a/clients/dfeApprenticeshipCertificates.ts
+++ b/clients/dfeApprenticeshipCertificates.ts
@@ -1,0 +1,27 @@
+import { Client } from "../interfaces/client.interface";
+
+const dfeApprenticeshipCertificates: Client = {
+  clientId: {
+    production: "CEWySFSPKpDSIsg7ooTZoaGYPLI",
+    integration: "CEWySFSPKpDSIsg7ooTZoaGYPLI",
+    nonProduction: "dfeApprenticeshipCertificates",
+  },
+  isAvailableInWelsh: false,
+  showInAccounts: true,
+  showInServices: false,
+  showInActivityHistory: true,
+  showInDeleteAccount: true,
+  showInSearchableList: false,
+  translations: {
+    en: {
+      header: "Apprenticeship certificates",
+      description:
+        "View, share or download your certificates, or view your results.",
+      linkText: "Go to your Apprenticeship certificates account",
+      linkUrl: "https://certificates.apprenticeship.education.gov.uk/certificates/list",
+    },
+  },
+  isOffboarded: false,
+};
+
+export default dfeApprenticeshipCertificates;

--- a/clients/index.ts
+++ b/clients/index.ts
@@ -104,6 +104,7 @@ import mojPensionRelief from "./mojPensionRelief";
 import jointNatureConservationCommitteeAirPollutionAssessment from "./jointNatureConservationCommitteeAirPollutionAssessment";
 import treeFellingLicence from "./treeFellingLicence";
 import dwpMaternityAllowance from "./dwpMaternityAllowance";
+import dfeApprenticeshipCertificates from "./dfeApprenticeshipCertificates";
 
 export {
   _testClient,
@@ -212,4 +213,5 @@ export {
   jointNatureConservationCommitteeAirPollutionAssessment,
   treeFellingLicence,
   dwpMaternityAllowance,
+  dfeApprenticeshipCertificates,
 };


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->

### What changed

Add rp registry entry for the DFE Apprenticeship service - Digital certification (Private beta)

The service goes live on June 1st. Their service url is not working yet, however it was indicated it should be working on time for their go live date.

The card has been reviewed by UCD already.



<img width="850" height="440" alt="Screenshot 2026-05-29 at 10 59 48" src="https://github.com/user-attachments/assets/4dc5a830-adbf-4d8f-99d3-e02e6c99dadb" />
