### PR TITLE
BAU: prevent PIP scripts

### DIFF
--- a/.github/workflows/detect-secrets.yaml
+++ b/.github/workflows/detect-secrets.yaml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install Python dependencies
-        run: pip install --require-hashes -r .github/workflows/requirements.txt
+        run: "pip install --require-hashes --only-binary :all: -r .github/workflows/requirements.txt"
 
       - name: Detect secrets
         run: git ls-files -z | xargs -0 python -m detect_secrets.pre_commit_hook --verbose --baseline .secrets.baseline


### PR DESCRIPTION
Prevent PIP from running scripts when installing dependencies