### PR TITLE
OLH-4137: Add DFE Register for NPQ service

### DIFF
--- a/clients/dfeRegisterForNPQ.ts
+++ b/clients/dfeRegisterForNPQ.ts
@@ -1,0 +1,28 @@
+import { Client } from "../interfaces/client.interface";
+
+const dfeRegisterForNPQ: Client = {
+  clientId: {
+    production: "DD1qQMnQ8UThae3vXwZVo59DbYM",
+    integration: "DD1qQMnQ8UThae3vXwZVo59DbYM",
+    nonProduction: "dfeRegisterForNPQ",
+  },
+  isAvailableInWelsh: false,
+  showInAccounts: true,
+  showInServices: false,
+  showInActivityHistory: true,
+  showInDeleteAccount: true,
+  showInSearchableList: true,
+  translations: {
+    en: {
+      header: "Register for a national professional qualification (NPQ)",
+      description: "Check your NPQ registration details and the outcome for courses you’ve completed.",
+      linkText: "Go to your NPQ account",
+      linkUrl: "https://register-national-professional-qualifications.education.gov.uk/sign-in",
+      startUrl: "https://register-national-professional-qualifications.education.gov.uk",
+      startText: "Register for a national professional qualification (NPQ)",
+    },
+  },
+  isOffboarded: false,
+};
+
+export default dfeRegisterForNPQ;

--- a/clients/index.ts
+++ b/clients/index.ts
@@ -108,6 +108,7 @@ import dfeApprenticeshipCertificates from "./dfeApprenticeshipCertificates";
 import earlyYearsTeacherFinancialIncentives from "./earlyYearsTeacherFinancialIncentives";
 import ofgemSupplierUploadPortal from "./ofgemSupplierUploadPortal";
 import farmingConnectSkillsHub from "./farmingConnectSkillsHub";
+import dfeRegisterForNPQ from "./dfeRegisterForNPQ";
 
 export {
   _testClient,
@@ -219,5 +220,6 @@ export {
   dfeApprenticeshipCertificates,
   earlyYearsTeacherFinancialIncentives,
   ofgemSupplierUploadPortal,
-  farmingConnectSkillsHub
+  farmingConnectSkillsHub,
+  dfeRegisterForNPQ
 };


### PR DESCRIPTION
The DFE "Register for a national professional qualification" service went live on the 23rd of June. 

<img width="697" height="304" alt="Screenshot 2026-06-24 at 10 13 47" src="https://github.com/user-attachments/assets/d9b785a7-93af-41cd-96ee-2e254bfaae63" />


Note that the searchable list URL provided by the RP/on the onboarding card was actually incorrect. 

The URL provided was https://register-national-professional-qualifications.education.gov.uk/registration but nothing is available at this address.
Although it hasn't officially been confirmed by Onboarding, it would appear that the correct URL is https://register-national-professional-qualifications.education.gov.uk/ so that is what we went with. 


https://github.com/user-attachments/assets/b3a307d2-3808-4c1f-8606-b0bb189e2b63

