### PR TITLE
BAU: Update dependabot to ignore major typescript dependency update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     ignore:
       - dependency-name: "node"
         versions: ["17.x", "18.x", "19.x"]
+      # Typescript v7 and above is incompatible with the version of ts-jest currently used on this repo
+      # TS v7 did not ship with an API. That is expected to arrive with v7.1 and to be implemented subsequently: https://github.com/kulshekhar/ts-jest/issues/5366
+      - dependency-name: "typescript"
+        versions: [">= 7.0.0"]
     commit-message:
       prefix: BAU
     groups:


### PR DESCRIPTION
Dependabot raised a PR to upgrade the version of typescript on this repo from v6.0.3 to v7.0.1.

There were errors caused by the fact that Typescript v7 is not currently supported by some of the dependencies we use, including `ts-jest`. It is expected to be integrated once a stable API is released.

This configuration update tells dependabot to ignore this major dependency update for now.
